### PR TITLE
Add a force_fully_evolved option

### DIFF
--- a/worlds/pokemon_crystal/options.py
+++ b/worlds/pokemon_crystal/options.py
@@ -149,6 +149,18 @@ class RandomizeWilds(Toggle):
     display_name = "Randomize Wilds"
 
 
+class ForceFullyEvolved(Range):
+    """
+    When an opponent uses a pokemon of the specified level or higher, restricts the species to only fully evolved pokemon.
+
+    Only applies when trainer parties are randomized.
+    """
+    display_name = "Force Fully Evolved"
+    range_start = 1
+    range_end = 100
+    default = 100
+
+
 class NormalizeEncounterRates(Toggle):
     """
     Normalizes the chance of encountering each wild Pokemon in a given area
@@ -469,6 +481,7 @@ class PokemonCrystalOptions(PerGameCommonOptions):
     randomize_berry_trees: RandomizeBerryTrees
     randomize_starters: RandomizeStarters
     randomize_wilds: RandomizeWilds
+    force_fully_evolved: ForceFullyEvolved
     normalize_encounter_rates: NormalizeEncounterRates
     randomize_static_pokemon: RandomizeStaticPokemon
     randomize_trainer_parties: RandomizeTrainerParties

--- a/worlds/pokemon_crystal/pokemon.py
+++ b/worlds/pokemon_crystal/pokemon.py
@@ -112,17 +112,38 @@ def randomize_starters(world: "PokemonCrystalWorld"):
     world.generated_starter_helditems = new_helditems
 
 
-def get_random_pokemon(world: "PokemonCrystalWorld", types=None, base_only=False):
-    # unown is excluded because it has a tendency to crash the game
-    if types is None or types[0] is None:
-        pokemon_pool = [pkmn_name for pkmn_name, pkmn_data in world.generated_pokemon.items() if
-                        pkmn_name != "UNOWN" and (pkmn_data.is_base or not base_only)]
-    else:
-        pokemon_pool = [pkmn_name for pkmn_name, pkmn_data in world.generated_pokemon.items()
-                        if pkmn_name != "UNOWN" and types[0] in pkmn_data.types or types[-1] in pkmn_data.types]
-        if len(pokemon_pool) == 0:
-            pokemon_pool = [pkmn_name for pkmn_name, _ in world.generated_pokemon.items() if
-                            pkmn_name != "UNOWN"]
+def get_random_pokemon(world: "PokemonCrystalWorld", types=None, base_only=False, force_fully_evolved_at=None, current_level=None):
+    def filter_out_pokemons(pkmn_name, pkmn_data):
+        # unown is excluded because it has a tendency to crash the game
+        if pkmn_name == "UNOWN":
+            return True
+
+        # If types are passed in, filter ou pokemons that do not match it
+        if types is not None:
+            if types[0] not in pkmn_data.types and types[-1] not in pkmn_data.types:
+                return True
+
+        # Exclude evolved pokemons when we only want base ones
+        if base_only and not pkmn_data.is_base:
+            return True
+
+        # If we have a level to force fully evolved at and the current level of the pokemon is passed in,
+        # exlude pokemons with evolutions from the list if the level is greater or equal than forced_fully_evolved
+        if force_fully_evolved_at is not None and current_level is not None:
+            if current_level >= force_fully_evolved_at and pkmn_data.evolutions:
+                return True
+
+        return False
+
+
+    pokemon_pool = [pkmn_name for pkmn_name, pkmn_data in world.generated_pokemon.items()
+                        if not filter_out_pokemons(pkmn_name, pkmn_data)]
+
+    # If there's no pokemon left, give up and shove everything back in, it can happen in some very rare edge cases
+    if not pokemon_pool:
+        pokemon_pool = [pkmn_name for pkmn_name, _ in world.generated_pokemon.items() if
+                        pkmn_name != "UNOWN"]
+
     return world.random.choice(pokemon_pool)
 
 

--- a/worlds/pokemon_crystal/trainers.py
+++ b/worlds/pokemon_crystal/trainers.py
@@ -31,7 +31,7 @@ def randomize_trainers(world: "PokemonCrystalWorld"):
                 if "LASS_3" in trainer_name:
                     new_pokemon = get_random_nezumi(world.random)
                 else:
-                    new_pokemon = get_random_pokemon(world, match_types)
+                    new_pokemon = get_random_pokemon(world, types=match_types, force_fully_evolved_at=world.options.force_fully_evolved, current_level=pkmn_data.level)
             if pkmn_data.item is not None:
                 # If this trainer has items, add an item
                 new_item = get_random_filler_item(world.random)


### PR DESCRIPTION
This refactors the way to filter out pokemons when getting a random one, fixing a bug where unown could appear when matching types if the second type of a pokemon matched (and is evaluated before or).