### PR TITLE
Update various items' usefulness status

### DIFF
--- a/worlds/pokemon_crystal/data/items.json
+++ b/worlds/pokemon_crystal/data/items.json
@@ -22,7 +22,7 @@
   },
   "BRIGHTPOWDER": {
     "name": "Brightpowder",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "GREAT_BALL": {
@@ -284,7 +284,7 @@
   },
   "EXP_SHARE": {
     "name": "Exp Share",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "OLD_ROD": {
@@ -396,7 +396,7 @@
   },
   "QUICK_CLAW": {
     "name": "Quick Claw",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "PSNCUREBERRY": {
@@ -411,12 +411,12 @@
   },
   "SOFT_SAND": {
     "name": "Soft Sand",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "SHARP_BEAK": {
     "name": "Sharp Beak",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "PRZCUREBERRY": {
@@ -436,7 +436,7 @@
   },
   "POISON_BARB": {
     "name": "Poison Barb",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "KINGS_ROCK": {
@@ -471,7 +471,7 @@
   },
   "SILVERPOWDER": {
     "name": "Silverpowder",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "BLU_APRICORN": {
@@ -481,7 +481,7 @@
   },
   "AMULET_COIN": {
     "name": "Amulet Coin",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "YLW_APRICORN": {
@@ -496,17 +496,17 @@
   },
   "CLEANSE_TAG": {
     "name": "Cleanse Tag",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "MYSTIC_WATER": {
     "name": "Mystic Water",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "TWISTEDSPOON": {
     "name": "Twistedspoon",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "WHT_APRICORN": {
@@ -516,7 +516,7 @@
   },
   "BLACKBELT_I": {
     "name": "Blackbelt",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "BLK_APRICORN": {
@@ -531,7 +531,7 @@
   },
   "BLACKGLASSES": {
     "name": "Blackglasses",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "SLOWPOKETAIL": {
@@ -541,7 +541,7 @@
   },
   "PINK_BOW": {
     "name": "Pink Bow",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "STICK": {
@@ -556,12 +556,12 @@
   },
   "NEVERMELTICE": {
     "name": "Nevermeltice",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "MAGNET": {
     "name": "Magnet",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "MIRACLEBERRY": {
@@ -586,7 +586,7 @@
   },
   "SPELL_TAG": {
     "name": "Spell Tag",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "RAGECANDYBAR": {
@@ -605,7 +605,7 @@
   },
   "BLUE_CARD": {
     "name": "Blue Card",
-    "classification": "USEFUL",
+    "classification": "FILLER",
     "tags": [
       "KeyItem",
       "Unique"
@@ -613,7 +613,7 @@
   },
   "MIRACLE_SEED": {
     "name": "Miracle Seed",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "THICK_CLUB": {
@@ -648,12 +648,12 @@
   },
   "HARD_STONE": {
     "name": "Hard Stone",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "LUCKY_EGG": {
     "name": "Lucky Egg",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "CARD_KEY": {
@@ -720,7 +720,7 @@
   },
   "CHARCOAL": {
     "name": "Charcoal",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "BERRY_JUICE": {
@@ -740,7 +740,7 @@
   },
   "DRAGON_FANG": {
     "name": "Dragon Fang",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "LEFTOVERS": {
@@ -760,7 +760,7 @@
   },
   "BERSERK_GENE": {
     "name": "Berserk Gene",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "SACRED_ASH": {
@@ -830,7 +830,7 @@
   },
   "POLKADOT_BOW": {
     "name": "Polkadot Bow",
-    "classification": "FILLER",
+    "classification": "USEFUL",
     "tags": []
   },
   "UP_GRADE": {


### PR DESCRIPTION
I am proposing this change in status of usefulness of many items.

My criteria is for them to be a "general applicable held item". This means usually items that boost a certain type. So it does not apply to pokemon-specific stuff like Stick or Lucky Punch.

Despite "splitting XP" I still like EXP Share.

Blue Card is hotly debated. There's pro and cons. I think it *should* remain useful IF the cap on answering Buenas Stuff is removed.