### PR TITLE
Fix trainer pokemon generation when match_types is off

### DIFF
--- a/worlds/pokemon_crystal/trainers.py
+++ b/worlds/pokemon_crystal/trainers.py
@@ -25,7 +25,7 @@ def randomize_trainers(world: "PokemonCrystalWorld"):
             new_item = pkmn_data.item
             new_moves = pkmn_data.moves
             if not is_rival_starter_pokemon(trainer_name, trainer_data, i):
-                match_types = [None, None]
+                match_types = None
                 if world.options.randomize_trainer_parties == RandomizeTrainerParties.option_match_types:
                     match_types = crystal_data.pokemon[pkmn_data.pokemon].types
                 if "LASS_3" in trainer_name:


### PR DESCRIPTION
This fixes a regression from b5f108c659d6b90640fe2565f4fb848a4c462b27 where I assumed that the default value (`None`) for the `types` parameter would be what one should pass to disable that filter. Turns out the trainer caller was actually  passing `[None, None]` instead.

This made it so without `match_types` on, it would filter out every pokemon every single time and end up in the fallback where it would choose from a full pool instead

Fixes #26