### PR TITLE
Added BST mode and first stage can evolve options to the randomize starter option

### DIFF
--- a/worlds/pokemon_crystal/options.py
+++ b/worlds/pokemon_crystal/options.py
@@ -151,6 +151,20 @@ class RandomizeStarters(Choice):
     option_vanilla = 0
     option_unevolved_only = 1
     option_completely_random = 2
+    option_first_stage_can_evolve = 3
+    option_base_stat_mode = 4
+    
+class StarterBST(NamedRange):
+    """
+    If you chose Base Stat Mode for your starters, what is the average base stat total you want your available starters to be?
+    """
+    display_name = "Starter BST Range"
+    default = 310
+    range_start = 195
+    range_end = 680
+    special_range_names = {
+        "normal_starters": 310
+    }
 
 
 class RandomizeWilds(Toggle):
@@ -534,6 +548,7 @@ class PokemonCrystalOptions(PerGameCommonOptions):
     randomize_pokegear: RandomizePokegear
     randomize_berry_trees: RandomizeBerryTrees
     randomize_starters: RandomizeStarters
+    starters_bst_average: StarterBST
     randomize_wilds: RandomizeWilds
     force_fully_evolved: ForceFullyEvolved
     normalize_encounter_rates: NormalizeEncounterRates


### PR DESCRIPTION
Thanks for contributing to the Pokémon Crystal Archipelago project!

## What does this add?
Added options to option.py to enable those modes and added a new option to select your bst average. Starts looking at 10% of your average and moves out if it can't find anything. There are at least 3 pokemon within 10% of any bst so until a blocklist is added for this I don't see any issues cropping up.

## Why do you want it to be added?
I want to be able to randomize starters and get more reasonable options

## Was this tested yet?
Fuzz tests returned no errors in generations