### PR TITLE
Fixes to regions.json

### DIFF
--- a/worlds/pokemon_crystal/data/regions.json
+++ b/worlds/pokemon_crystal/data/regions.json
@@ -1770,7 +1770,6 @@
     "exits": [
       "REGION_ROUTE_3",
       "REGION_ROUTE_4",
-      "REGION_MOUNT_MOON",
       "REGION_MOUNT_MOON_SQUARE"
     ],
     "locations": [],
@@ -2136,7 +2135,9 @@
       "OLIVINE_LIGHTHOUSE_5F_RARE_CANDY",
       "OLIVINE_LIGHTHOUSE_5F_SUPER_REPEL",
       "OLIVINE_LIGHTHOUSE_5F_TM_SWAGGER",
-      "OLIVINE_LIGHTHOUSE_5F_HIDDEN_HYPER_POTION"
+      "OLIVINE_LIGHTHOUSE_5F_HIDDEN_HYPER_POTION",
+      "ITEM_FROM_BIRD_KEEPER_DENIS",
+      "ITEM_FROM_SAILOR_ERNEST"
     ],
     "events": []
   },
@@ -2147,8 +2148,6 @@
     ],
     "locations": [
       "OLIVINE_LIGHTHOUSE_6F_SUPER_POTION",
-      "ITEM_FROM_BIRD_KEEPER_DENIS",
-      "ITEM_FROM_SAILOR_ERNEST"
     ],
     "events": [
       "EVENT_JASMINE_EXPLAINED_AMPHYS_SICKNESS",
@@ -4208,8 +4207,7 @@
     ],
     "locations": [
       "SPROUT_TOWER_1F_PARLYZ_HEAL",
-      "ITEM_FROM_SAGE_CHOW",
-      "FRUITTREE_VIOLET_CITY"
+      "ITEM_FROM_SAGE_CHOW"
     ],
     "events": []
   },
@@ -4693,7 +4691,8 @@
     "locations": [
       "VIOLET_CITY_HIDDEN_HYPER_POTION",
       "VIOLET_CITY_PP_UP",
-      "VIOLET_CITY_RARE_CANDY"
+      "VIOLET_CITY_RARE_CANDY",
+      "FRUITTREE_VIOLET_CITY"
     ],
     "events": []
   },


### PR DESCRIPTION
Thanks for contributing to the Pokémon Crystal Archipelago project!

## What does this fix?
Relocates Violet Fruit Tree, Olivine Lighthouse Trainers to their correct regions.
Removes Mt. Moon as an exit of Mt. Moon.

## Why do you want it to be added?
Bugs gotta be fixed.

## Was this tested yet?
No.