### PR TITLE
Add "Ball" tag to Apricorn / Park Balls

### DIFF
--- a/worlds/pokemon_crystal/data/items.json
+++ b/worlds/pokemon_crystal/data/items.json
@@ -772,7 +772,9 @@
   "HEAVY_BALL": {
     "name": "Heavy Ball",
     "classification": "FILLER",
-    "tags": []
+    "tags": [
+      "Ball"
+    ]
   },
   "FLOWER_MAIL": {
     "name": "Flower Mail",
@@ -782,17 +784,23 @@
   "LEVEL_BALL": {
     "name": "Level Ball",
     "classification": "FILLER",
-    "tags": []
+    "tags": [
+      "Ball"
+    ]
   },
   "LURE_BALL": {
     "name": "Lure Ball",
     "classification": "FILLER",
-    "tags": []
+    "tags": [
+      "Ball"
+    ]
   },
   "FAST_BALL": {
     "name": "Fast Ball",
     "classification": "FILLER",
-    "tags": []
+    "tags": [
+      "Ball"
+    ]
   },
   "LIGHT_BALL": {
     "name": "Light Ball",
@@ -802,17 +810,23 @@
   "FRIEND_BALL": {
     "name": "Friend Ball",
     "classification": "FILLER",
-    "tags": []
+    "tags": [
+      "Ball"
+    ]
   },
   "MOON_BALL": {
     "name": "Moon Ball",
     "classification": "FILLER",
-    "tags": []
+    "tags": [
+      "Ball"
+    ]
   },
   "LOVE_BALL": {
     "name": "Love Ball",
     "classification": "FILLER",
-    "tags": []
+    "tags": [
+      "Ball"
+    ]
   },
   "NORMAL_BOX": {
     "name": "Normal Box",
@@ -861,7 +875,9 @@
   "PARK_BALL": {
     "name": "Park Ball",
     "classification": "FILLER",
-    "tags": []
+    "tags": [
+      "Ball"
+    ]
   },
   "RAINBOW_WING": {
     "name": "Rainbow Wing",


### PR DESCRIPTION
## What does this add?
The Poke Balls that are normally made from Apricorns (Fast, Friend, Heavy, Level, Love, Lure, and Moon Balls), as well as the Park Ball from the Bug-Catching Contest, now have the "Ball" tag in items.json.

## Why do you want it to be added?
It's mostly a consistency thing. All the other standard-line Poke Balls have the "Ball" tag, but not any of the special ones as mentioned.

## Was this tested yet?
I quickly generated a solo seed and it seems like nothing's changed in terms of logic, so this change shouldn't break anything. I assume that these tags will be made more useful later, so getting ahead of changes like this will save a bit of time in future.