### PR TITLE
Fix compatibility with AP 0.5.1

### DIFF
--- a/worlds/pokemon_crystal/__init__.py
+++ b/worlds/pokemon_crystal/__init__.py
@@ -188,7 +188,7 @@ class PokemonCrystalWorld(World):
                             self.player, self.player_name)
             self.options.remote_items.value = Toggle.option_true
 
-        self.blocklisted_moves = {move.replace(" ", "_").upper() for move in self.options.move_blocklist}
+        self.blocklisted_moves = {move.replace(" ", "_").upper() for move in self.options.move_blocklist.value}
 
     def create_regions(self) -> None:
         regions = create_regions(self)


### PR DESCRIPTION
710cf4ebba67198133bd02150b08e757c3fc9c0d made `VerifyKey` options iterable but is only present in 0.6.0

This commit basically inlines what that method is doing to fix compat with 0.5.1