### PR TITLE
Apply Level Boosting before Randomize Trainers

### DIFF
--- a/worlds/pokemon_crystal/__init__.py
+++ b/worlds/pokemon_crystal/__init__.py
@@ -338,13 +338,13 @@ class PokemonCrystalWorld(World):
 
         self.finished_level_scaling.wait()
 
+        if self.options.boost_trainers:
+            boost_trainer_pokemon(self)
+
         if self.options.randomize_trainer_parties.value:
             randomize_trainers(self)
         elif self.options.randomize_learnsets.value:
             vanilla_trainer_movesets(self)
-
-        if self.options.boost_trainers:
-            boost_trainer_pokemon(self)
 
         if self.options.randomize_static_pokemon.value:
             randomize_static_pokemon(self)


### PR DESCRIPTION
Thanks for contributing to the Pokémon Crystal Archipelago project!

## What does this add?
Makes `Level Boosting` occur before `Randomize Trainers`, which is where `Force Fully Evolved` is applied.

## Why do you want it to be added?
[Possible bug report, v3.1.1](https://discord.com/channels/731205301247803413/1057476528419647572/1360402322534043808)
If a Pokemon's vanilla scaled level is below the `Force Fully Evolved` threshold, it will not be evolved.
However, later on in `Level Boosting` it could end up above the threshold, and would stay unevolved.

## Was this tested yet?
No.