### PR TITLE
Fix force fully evolved for rival's starter

### DIFF
--- a/worlds/pokemon_crystal/__init__.py
+++ b/worlds/pokemon_crystal/__init__.py
@@ -338,13 +338,13 @@ class PokemonCrystalWorld(World):
 
         self.finished_level_scaling.wait()
 
+        if self.options.boost_trainers:
+            boost_trainer_pokemon(self)
+
         if self.options.randomize_trainer_parties.value:
             randomize_trainers(self)
         elif self.options.randomize_learnsets.value:
             vanilla_trainer_movesets(self)
-
-        if self.options.boost_trainers:
-            boost_trainer_pokemon(self)
 
         if self.options.randomize_static_pokemon.value:
             randomize_static_pokemon(self)

--- a/worlds/pokemon_crystal/trainers.py
+++ b/worlds/pokemon_crystal/trainers.py
@@ -17,6 +17,18 @@ def is_rival_starter_pokemon(trainer_name, trainer_data, index):
     return index == len(trainer_data.pokemon) - 1
 
 
+def get_last_evolution(pokemon, random):
+    """
+    Returns the latest possible evolution for a pokemon.
+    If there's more than one way down through the evolution line, one is picked at random
+    """
+    pkmn_data = crystal_data.pokemon[pokemon]
+    if not pkmn_data.evolutions:
+        return pokemon
+
+    return get_last_evolution(random.choice(pkmn_data.evolutions).pokemon, random)
+
+
 def randomize_trainers(world: "PokemonCrystalWorld"):
     for trainer_name, trainer_data in world.generated_trainers.items():
         new_party = trainer_data.pokemon
@@ -24,10 +36,16 @@ def randomize_trainers(world: "PokemonCrystalWorld"):
             new_pokemon = pkmn_data.pokemon
             new_item = pkmn_data.item
             new_moves = pkmn_data.moves
-            if not is_rival_starter_pokemon(trainer_name, trainer_data, i):
+
+            # If the current pokemon is rival's starter, don't change its evolution line
+            if is_rival_starter_pokemon(trainer_name, trainer_data, i):
+                if pkmn_data.level >= world.options.force_fully_evolved:
+                    new_pokemon = get_last_evolution(new_pokemon, world.random)
+            else:
                 match_types = None
                 if world.options.randomize_trainer_parties == RandomizeTrainerParties.option_match_types:
                     match_types = crystal_data.pokemon[pkmn_data.pokemon].types
+
                 if "LASS_3" in trainer_name:
                     new_pokemon = get_random_nezumi(world.random)
                 else:


### PR DESCRIPTION
Because rival's starter is special as we keep it from start to finish,
it wasn't getting force_fully_evolved applied to it properly.

We cannot use `get_random_pokemon` as we need to make sure that we
don't evolve's rival starter randomly throughout the fights. Instead, if
we're past the force_fully_evolved threshold, we just resolve the max
evolution and set the pokemon as that.

An easy way to test this patch is to apply the following diff and then
run the fuzzer.

```diff
diff --git a/worlds/pokemon_crystal/rom.py b/worlds/pokemon_crystal/rom.py
index 9d9be0c3..4c117232 100644
--- a/worlds/pokemon_crystal/rom.py
+++ b/worlds/pokemon_crystal/rom.py
@@ -261,6 +261,9 @@ def generate_output(world: "PokemonCrystalWorld", output_directory: str, patch:
         address += trainer_data.name_length + 1  # skip name and type
         for pokemon in trainer_data.pokemon:
             pokemon_data = [pokemon.level, data.pokemon[pokemon.pokemon].id]
+            if world.options.randomize_trainer_parties and pokemon.level >= world.options.force_fully_evolved and not trainer_name == "LASS_3":
+                assert not data.pokemon[pokemon.pokemon].evolutions, f"{pokemon.level}, {pokemon.pokemon}, {trainer_name}"
             if pokemon.item is not None:
                 item_id = item_const_name_to_id(pokemon.item)
                 pokemon_data.append(item_id)
```

This includes the commit from #163 which can be verified is correct with the same rom.py patch by running the fuzzer before/after and seeing failures go way up.