### PR TITLE
Add rules for trainers in Radio Tower 1F/2F

### DIFF
--- a/worlds/pokemon_crystal/rules.py
+++ b/worlds/pokemon_crystal/rules.py
@@ -387,6 +387,12 @@ def set_rules(world: "PokemonCrystalWorld") -> None:
     set_rule(get_location("Radio Tower 4F - Pink Bow from Mary"),
              lambda state: state.has("EVENT_CLEARED_RADIO_TOWER", world.player))
 
+    set_rule(get_location("GRUNTM_3"), has_rocket_badges)
+    set_rule(get_location("GRUNTM_4"), has_rocket_badges)
+    set_rule(get_location("GRUNTM_5"), has_rocket_badges)
+    set_rule(get_location("GRUNTM_6"), has_rocket_badges)
+    set_rule(get_location("GRUNTF_2"), has_rocket_badges)
+
     if trainersanity():
         set_rule(get_location("Radio Tower 1F - Grunt"), has_rocket_badges)
 


### PR DESCRIPTION
Thanks for contributing to the Pokémon Crystal Archipelago project!

## What does this add?
Access rules for Rockets in Radio Tower 1F and 2F for level scaling.

## Why do you want it to be added?
[Bug Report](https://discord.com/channels/731205301247803413/1057476528419647572/1361113013465382944
)

## Was this tested yet?
No.