### PR TITLE
feat: Load basic phone trap scripts from data file instead of code

### DIFF
--- a/worlds/pokemon_crystal/data.py
+++ b/worlds/pokemon_crystal/data.py
@@ -3,6 +3,7 @@ from enum import Enum
 from typing import Dict, List, NamedTuple, Set, FrozenSet, Any, Union, Optional
 
 import orjson
+import yaml
 
 from BaseClasses import ItemClassification
 
@@ -208,6 +209,15 @@ class FlyRegion(NamedTuple):
     name: str
     region_id: str
 
+class PhoneScriptData:
+    name: str
+    caller: str
+    script: List[str]
+
+    def __init__(self, name: str, caller: str, script: List[str]):
+        self.name = name
+        self.caller = caller
+        self.script = script
 
 class PokemonCrystalData:
     rom_version: int
@@ -280,6 +290,8 @@ class PokemonCrystalMapSizeData(NamedTuple):
 def load_json_data(data_name: str) -> Union[List[Any], Dict[str, Any]]:
     return orjson.loads(pkgutil.get_data(__name__, "data/" + data_name).decode('utf-8-sig'))
 
+def load_yaml_data(data_name: str) -> Union[List[Any], Dict[str, Any]]:
+    return yaml.safe_load(pkgutil.get_data(__name__, "data/" + data_name).decode('utf-8-sig'))
 
 data = PokemonCrystalData()
 
@@ -634,5 +646,12 @@ def _init() -> None:
     for map_name, map_size in map_size_data.items():
         data.map_sizes[map_name] = PokemonCrystalMapSizeData(map_size[0], map_size[1])
 
+    data.phone_scripts = []
+    phone_yaml = load_yaml_data("phone_data.yaml")
+    for script_name, script_data in phone_yaml.items():
+        try:
+            data.phone_scripts.append(PhoneScriptData(script_name, script_data.get("caller"), script_data.get("script")))
+        except Exception as ex:
+            raise ValueError(f"Error processing phone script '{script_name}': {ex}") from ex
 
 _init()

--- a/worlds/pokemon_crystal/data/phone_data.yaml
+++ b/worlds/pokemon_crystal/data/phone_data.yaml
@@ -1,0 +1,716 @@
+
+ffxiv:
+  caller: withheld
+  script:
+    - |
+      Hi, <player>!
+    - |
+      Have you heard of
+      the critically
+    - |
+      acclaimed MMORPG
+      Final Fantasy XIV?
+    - |
+      With an expanded
+      free trial which
+    - |
+      you can play
+      through the
+    - |
+      entirety of A
+      Realm Reborn and
+    - |
+      the award-winning
+      Heavensward
+    - |
+      expansion
+      and also the
+    - |
+      award-winning
+      Stormblood
+    - |
+      expansion
+      up to Lv.70 for
+    - |
+      free with no
+      restrictions on
+    - |
+      playtime?
+    - |
+      Play today!
+
+
+brock_oven:
+  caller: brock
+  script:
+    - |
+      Why do they
+      call it OVEN…
+    - |
+      when you OF IN
+      the COLD FOOD…
+    - |
+      OF OUT hot eat
+      the FOOD?
+    - |
+      Really makes you
+      think…
+
+
+gura_call:
+  caller: withheld
+  script:
+    - |
+      H-Hello ma'am…
+    - |
+      Do you have a
+      moment to talk
+    - |
+      about our lord and
+      savior LIGHTNING
+      MCQUEEN?
+    - |
+      He's the star of
+      several feature
+      films, such as
+    - |
+      CARS, CARS 2,
+      CARS 3, PLANES:
+      FIRE & RESCUE,
+    - |
+      FINDING DORY, TOY
+      STORY 3, COCO,
+    - |
+      and RALPH BREAKS
+      THE INTERNET,
+    - |
+      as well as other
+      short films such
+      as-
+    - |
+      K-KINGDOM HEARTS?
+
+
+regi_call:
+  caller: withheld
+  script:
+    - |
+      REGIROCK: ÜN ÜN ÜN
+      $Ae▶&!→ ,♀é▷Ö
+    - |
+      ÜN ÜN ÜN ÜN ÜN ÜN
+      AAAAAAOOOOOOOORT
+    - |
+      REGISTEEL: 1001000
+      1000101 1001100
+      1001100 1001111
+
+
+eusine_call:
+  caller: eusine
+  script:
+    - |
+      Hiya, <player>!
+      It's EUSINE!
+    - |
+      I just wanted to
+      call you about
+    - |
+      a discovery I
+      made. A baby
+      SUICUNE!
+    - |
+      That's right, it's
+      small and blue,
+    - |
+      large head with
+      antennae of some
+      kind.
+    - |
+      It has no arms,
+      but somehow it
+      learned ICE PUNCH!
+
+
+slowpoke_call:
+  caller: withheld
+  script:
+    - |
+      Hi, hello?
+    - |
+      I'm calling about
+      an amazing invest-
+      ment opportunity:
+    - |
+      Just for you, a
+      delicious, mouth-
+    - |
+      watering, tender
+      SLOWPOKETAIL for
+    - |
+      the low low price
+      of ¥1000000!
+    - |
+      Hello? Are you
+      still there?
+
+
+elm_hacked_call:
+  caller: elm
+  script:
+    - |
+      <player>?
+      Oh it's terrible.
+    - |
+      I got a call from
+    - |
+      <POKE>GEAR tech-
+      nical support,
+    - |
+      or so they said!
+    - |
+      They took my
+      number, my
+    - |
+      <POKE>PAY account,
+    - |
+      Gosh, even all my
+      PRIMEAPES are gone
+    - |
+      <player> got ELM's
+      new phone number.
+    - |
+      Whatever will I
+      do…
+
+
+mom_password_call:
+  caller: mom
+  script:
+    - |
+      Hello?
+    - |
+      Hi <player>…
+      I was going to
+    - |
+      buy something
+      nice for you,
+    - |
+      but I accident-
+      ally spent the
+    - |
+      money on BLUE
+      CARD points.
+    - |
+      I promise I'll
+      make it up to you,
+    - |
+      but later,
+      PASSWORD is
+      starting now!
+
+
+warranty_call:
+  caller: withheld
+  script:
+    - |
+      Hello, we're
+      trying to reach
+    - |
+      you about your
+      BICYCLE's ex-
+      tended warranty-
+
+
+bill_id_call:
+  caller: bill
+  script:
+    - |
+      Gugyoo…
+      Guooh! Pijji!
+    - |
+      Ha! Fooled you!
+      Those aren't 
+    - |
+      <POKE>MON
+    - |
+      It's actually me,
+      BILL!
+    - |
+      Wh-You knew?
+      Caller ID?
+    - |
+      Rats, foiled by my
+      own invention
+      again
+
+
+elm_jsr_call:
+  caller: elm
+  script:
+    - |
+      <player>, how are
+      things going?
+    - |
+      I called because
+      something weird is
+    - |
+      happening with the
+      radio broadcasts.
+    - |
+      They were talking
+      about FUNKY FRESH
+      BEATS.
+    - |
+      TEAM ROCKET must
+      be running some
+    - |
+      kind of pirate
+      radio station…
+
+
+bike_loyalty_call:
+  caller: bikeshop
+  script:
+    - |
+      Hiya <player>!
+      We're calling
+      around
+    - |
+      to spread the word
+      about our new
+      loyalty program!
+    - |
+      On your 10th
+      purchase of any
+      BICYCLE, you get
+    - |
+      a BIKE VOUCHER,
+      free of charge!
+    - |
+      We're also
+      offering a 
+      discount!
+    - |
+      A brand new
+      BICYCLE for
+      ¥999999.99!
+
+
+ppip_call:
+  caller: withheld
+  script:
+    - |
+      THIS IS AN AUTO-
+      MATED MESSAGE
+    - |
+      FROM THE PORYGON
+      POLITICAL
+      INTERESTS PARTY,
+    - |
+      OR P P I P FOR
+      SHORT.
+    - |
+      WE CAMPAIGN FOR
+      PORYGON ISSUES,
+      PORYGON2 ISSUES
+    - |
+      AND ISSUES OF
+      ANY OTHER POT-
+      ENTIAL PORYGON
+    - |
+      ISSUES SUCH AS:
+    - |
+      PENSIONS FOR
+      VETERAN ELECTRIC
+      SOLDIERS,
+    - |
+      AND UNFAIR
+      MALIGNMENT FOR THE
+    - |
+      UNFORTUNATE
+      EVENTS OF 16. DEC
+      1997.
+    - |
+      PLEASE VOTE FOR
+      US IN THE UPCOMING
+    - |
+      JOHTO LOCAL
+      ELECTIONS.
+
+
+bill_eevee_call:
+  caller: bill
+  script:
+    - |
+      Hey <player>!
+    - |
+      I have just
+      completed some
+    - |
+      research into
+      EEVEE and its
+      evolutions!
+    - |
+      I have been able
+      to scientif-
+
+
+elm_kyogre_call:
+  caller: elm
+  script:
+    - |
+      Hi, Mr. <POKE>MON?
+      Just following up
+      on your email.
+    - |
+      The way I see it,
+      KYOGRE is the one
+      surrounded!
+    - |
+      What's under the
+      ocean? More
+      earth!
+    - |
+      Oh, <player>?!
+      I must have called
+      the wrong number…
+
+
+elm_mew_call:
+  caller: elm
+  script:
+    - |
+      Oh… <player>…
+    - |
+      That red-headed
+      kid came back
+      to the lab.
+    - |
+      He said he would
+      tell me where to
+    - |
+      find a rare <POKE>-
+      MON if I didn't
+      call the police.
+    - |
+      Long story short,
+      I've been pushing
+    - |
+      on this truck
+      for hours now,
+    - |
+      and still no
+      sight of the
+      thing…
+
+
+bank_of_mom_1:
+  caller: bank_of_mom
+  script:
+    - |
+      Hello, <player>.
+      We're calling to
+    - |
+      let you know that
+      your latest bank
+    - |
+      statement is now
+      available online.
+    - |
+      Thank you for
+      managing your
+      finances with
+    - |
+      BANK of MOM.
+
+
+bank_of_mom_2:
+  caller: bank_of_mom
+  script:
+    - |
+      Hello, <player>.
+      We're calling to
+    - |
+      ask you about
+      some suspicious
+    - |
+      transactions
+      made with your
+      bank account.
+    - |
+      Today there were
+      3 purchases of
+      SUPER POTIONs
+    - |
+      from an unknown
+      location.
+    - |
+      Okay, we can
+      unfreeze your
+      account.
+    - |
+      Thank you for
+      managing your
+      finances with
+    - |
+      BANK of MOM.
+
+
+diglett_call:
+  caller: elm
+  script:
+    - |
+      Hi, <player>!
+      I was doing some
+      research on
+    - |
+      DIGLETT and disc-
+      covered something
+      remarkable!
+    - |
+      For ages, the
+      underside of
+      DIGLETT and
+    - |
+      DUGTRIO have re-
+      mained a mystery,
+      but I've finally
+    - |
+      figured it out!
+      It took four
+      X-RAYS, twenty
+    - |
+      ultrasounds, a
+      seismograph,
+      3 well timed
+    - |
+      photos, 100 cups
+      of coffee,
+      and 2 assistants
+    - |
+      to finally find
+      out th-- --lly--
+    - |
+      --llo? Breaking--
+      --up? <player>?--
+
+
+team_rocket_call:
+  caller: withheld
+  script:
+    - |
+      Who are we, you
+      ask?
+    - |
+      Prepare for
+      trouble!
+    - |
+      Make it double!
+    - |
+      To protect the 
+      world from
+      devastation!
+    - |
+      To unite all
+      peoples within our
+      nation!
+    - |
+      To denounce the
+      evils of truth
+      and love!
+    - |
+      To extend our
+      reach to the stars
+      above!
+    - |
+      JESSIE…
+      JAMES…
+    - |
+      TEAM ROCKET blasts
+      off at the speed
+      of light!
+    - |
+      Surrender now or
+      prepare to fight!
+    - |
+      MEOWTH!
+      That's right!
+
+
+happy_birthday:
+  caller: mom
+  script:
+    - |
+      Hi, <player>!
+    - |
+      Happy Birthday
+      to you! Happy
+      Birthday to y-
+    - |
+      What do you mean
+      it's not your
+      birthday? Is today
+    - |
+      not March 23rd?
+      Oh, well,
+      nevermind then!
+
+
+lance_cape:
+  caller: withheld
+  script:
+    - |
+      Hello? LANCE?
+    - |
+      I wanted to let
+      you know that your
+      new champion
+    - |
+      outfit can't
+      include a cape,
+      dahling.
+    - |
+      Not convinced?
+      LEON! His cape
+    - |
+      gets so dirty, he
+      has to clean it
+    - |
+      every day! CLAIR!
+      Her DRAGONAIR
+    - |
+      sets it on fire
+      all the time!
+    - |
+      And don't get me
+      started on
+    - |
+      WALLACE! His
+      gets soaked and
+      drags him down!
+    - |
+      …Huh? Oh!
+      Wrong number!
+
+
+flareon_call:
+  caller: withheld
+  script:
+    - |
+      Hey, <player>!
+    - |
+      Did you know that
+      in terms of human
+    - |
+      companionship,
+      FLAREON is
+    - |
+      objectively the
+      most huggable
+    - |
+      <POKE>MON?
+    - |
+      While their max
+      temperature is--
+
+
+blender_call:
+  caller: mom
+  script:
+    - |
+      Hello?
+    - |
+      Hi <player>!
+      How have you been?
+    - |
+      Oh, wait! I should
+      tell you what
+      I had for lunch!
+    - |
+      Remember when we
+      got Subway last
+      week?
+    - |
+      Well, I put it in
+      a blender and
+      ate it!
+    - |
+      It was so good!
+    - |
+      Hello?
+      <player> are you
+      there?
+
+
+call_your_mother:
+  caller: withheld
+  script:
+    - |
+      Here's some
+      advice…
+    - |
+      Brush your teeth,
+      be kind to to one
+      another
+    - |
+      Take 10 minutes to
+      call your mother.
+    - |
+      It's been three
+      long weeks now,
+    - |
+      A text is not
+      enough. You gotta
+      get on the phone,
+    - |
+      and give your
+      mother a call!
+    - |
+      You gotta do what
+      I say--!
+
+
+fuzz_call:
+  caller: out_of_area
+  script:
+    - |
+      ................
+      ................
+      ................
+    - |
+      ................
+      ................
+      ................
+    - |
+      ..F.............
+      ................
+      ................
+    - |
+      ................
+      ................
+      ................
+
+
+daily_wowers_call:
+  caller: out_of_area
+  script:
+    - |
+      It's time for
+      daily WOWers!
+    - |
+      chrisWOW chris-
+      WOW chrisWOW
+      chrisWOW
+    - |
+      chrisWOW chris-
+      WOW chrisWOW
+      chrisWOW
+    - |
+      WOWOWOWOWOWOW
+      OWOWOWOWOWOWO
+      WOWOWOWOWOWOW
+    - |
+      OWOWOWOWOWOWO
+      WOWOWOWOWOWOW
+      OWOW x247chWOW

--- a/worlds/pokemon_crystal/docs/phone_data.md
+++ b/worlds/pokemon_crystal/docs/phone_data.md
@@ -2,11 +2,50 @@
 
 ## Technical Guidelines
 - Every phone call can only be a max of 1024 bytes (1kib). This will be assured via unit test. Just be aware there is a limit.
-- A line is max 17 characters long. This will be assured via unit test. Just be aware of the limit when writing it.
-- When using RIVAL or PLAYER variables, assume they are the max of 6 characters.
-- We cannot add new callers. [All available callers can be found here.](https://github.com/gerbiljames/Archipelago-Crystal/blob/2499f228aefadeb49b627f0e90a2f0a338277d26/worlds/pokemon_crystal/phone_data.py#L39-L49) Use None / Withheld / Out of Area / at your discretion
-- The "commands" you can use (variables, etc.) [can be found here with explanations.](https://github.com/gerbiljames/Archipelago-Crystal/blob/2499f228aefadeb49b627f0e90a2f0a338277d26/worlds/pokemon_crystal/phone_data.py#L51-L60)
-- Only submit ONE Phone Trap per Pull Request
+- A line is max 18 characters long. This will be assured via unit test and validated during generation. Just be aware of the limit when writing it.
+- Each section (paragraph) is up to 3 lines long. The text box will reset after each section.
+- When using RIVAL or PLAYER variables, assume they are the max of 7 characters.
+- We cannot add new callers. The available callers are:
+   - none
+   - mom
+   - bikeshop
+   - bill
+   - elm
+   - withheld
+   - bank_of_mom
+   - brock
+   - eusine
+   - out_of_area
+
+The basic phone scripts are defined in `data/phone_data.yaml`.
+
+Each script follows the convention:
+
+```yaml
+sample_script:
+  caller: out_of_area
+  script:
+    - |
+      The quick brown
+      fox jumps over
+      the lazy dog.
+    - |
+      The placeholders
+      <player>, <rival>,
+      and <POKE> may be used.
+```
+
+The script is identified as "sample_script", and the call is from "OUT OF AREA".
+Each new paragraph is denoted with YAML syntax `- |` which starts a new array member as a multi-line literal scalar.
+It is strongly recommended to use this for readability and to avoid accidental YAML special behavior.
+
+The placeholder tags have these effects:
+
+| Placeholder | Effect         | Size |
+| ----------- | -------------- | ---- |
+| <player>    | Player name    | 7    |
+| <rival>     | Rival name     | 7    |
+| <POKE>      | Literal "POKÉ" | 4    |
 
 ## Content Guidelines
 - Look at the original 16 phone traps. We want the kind of humor to be adjacent to that.
@@ -16,6 +55,7 @@
 - They *can* contain references to copyrighted content. They *cannot* contain copyrighted content.
 
 # Submission Considerations
+- Only submit ONE Phone Trap per Pull Request
 - A submission has to be approved by at least 5 users by giving a "Thumbs Up" reaction on the PR
 - Two of these approvals need to be @gerbiljames and @palex00
 - This requirement may change as we learn with the system

--- a/worlds/pokemon_crystal/docs/phone_data.md
+++ b/worlds/pokemon_crystal/docs/phone_data.md
@@ -43,9 +43,9 @@ The placeholder tags have these effects:
 
 | Placeholder | Effect         | Size |
 | ----------- | -------------- | ---- |
-| <player>    | Player name    | 7    |
-| <rival>     | Rival name     | 7    |
-| <POKE>      | Literal "POKÉ" | 4    |
+| \<player\>  | Player name    | 7    |
+| \<rival\>   | Rival name     | 7    |
+| \<POKE\>    | Literal "POKÉ" | 4    |
 
 ## Content Guidelines
 - Look at the original 16 phone traps. We want the kind of humor to be adjacent to that.

--- a/worlds/pokemon_crystal/phone.py
+++ b/worlds/pokemon_crystal/phone.py
@@ -39,7 +39,7 @@ def generate_phone_traps(world: "PokemonCrystalWorld"):
         phone_traps_list += ["basic"] * (16 - len(phone_traps_list))
         world.random.shuffle(phone_traps_list)
 
-        basic_calls = get_shuffled_basic_calls(world.random)
+        basic_calls = get_shuffled_basic_calls(world.random, data.phone_scripts)
 
     location_call_indices = [0] * 16
     phone_traps = []

--- a/worlds/pokemon_crystal/phone_data.py
+++ b/worlds/pokemon_crystal/phone_data.py
@@ -2,8 +2,10 @@ import copy
 from typing import List, Union
 
 from BaseClasses import Location
+from .data import PhoneScriptData
 from .utils import convert_to_ingame_text
 
+import orjson
 
 class ScriptLine:
     contents: List[Union[str, int]]
@@ -35,7 +37,6 @@ class PhoneScript:
             out_bytes += line.get_bytes()
         return out_bytes
 
-
 caller_none = 0x00
 caller_mom = 0x01
 caller_bikeshop = 0x02
@@ -48,6 +49,19 @@ caller_brock = 40
 caller_eusine = 41
 caller_out_of_area = 42
 
+caller_string_to_id_map = {
+    "none": caller_none,
+    "mom": caller_mom,
+    "bikeshop": caller_bikeshop,
+    "bill": caller_bill,
+    "elm": caller_elm,
+    "withheld": caller_withheld,
+    "bank_of_mom": caller_bank_of_mom,
+    "brock": caller_brock,
+    "eusine": caller_eusine,
+    "out_of_area": caller_out_of_area
+}
+
 text_cmd = 0x00  # Initiates the text at the beginning of the phone call
 para_cmd = 0x51  # Starts a new paragraph, clearing the text box
 line_cmd = 0x4f  # Starts a new line (always the 2nd line)
@@ -59,6 +73,84 @@ play_g_cmd = 0x14  # Outputs player name
 player_cmd = 0x52  # Outputs player name
 rival_cmd = 0x53  # Outputs rival name
 poke_cmd = 0x54  # Outputs POKÉ
+
+placeholder_map = {
+    "<POKE>": poke_cmd,
+    "<player>": player_cmd,
+    "<rival>": rival_cmd
+}
+
+cmd_line_size = {
+    poke_cmd: 4,
+    player_cmd: 7,
+    rival_cmd: 7,
+}
+
+def script_line_to_blocks(first_cmd: int, line: str):
+    blocks = [first_cmd]
+    size = 0
+    while line:
+        placeholder_start = line.find("<")
+        placeholder_end = line.find(">", placeholder_start)
+
+        if placeholder_start != -1 and placeholder_end != -1:
+            # append the string up until the command placeholder
+            if placeholder_start > 0:
+                blocks.append(line[:placeholder_start])
+                size += placeholder_start
+
+            # extract the command
+            cmd_string = line[placeholder_start:placeholder_end + 1]
+            cmd = placeholder_map.get(cmd_string, None)
+            if cmd is None:
+                raise ValueError(f"Unknown placeholder: {cmd_string}")
+            blocks.append(placeholder_map[cmd_string])
+            size += cmd_line_size[cmd]
+
+            # remove the processed command
+            line = line[placeholder_end + 1:]
+        else:
+            # plain text only
+            blocks.append(line)
+            size += len(line)
+            break
+    if size > 18:
+        raise ValueError(f"Line too long: '{line}' measured at {size} characters")
+
+    return blocks
+
+
+def data_to_script(data: PhoneScriptData):
+    script_lines = []
+
+    caller = caller_string_to_id_map.get(data.caller, None)
+    if caller is None:
+        raise ValueError(f"Invalid caller '{data.caller}' in the phone script '{data.name}'.")
+
+    for paragraph in data.script:
+        if not isinstance(paragraph, str):
+            raise ValueError(f"Invalid script data encountered in phone script '{data.name}': Expected string, got {type(paragraph).__name__}")
+
+        lines = paragraph.rstrip("\n").split("\n")
+        if len(lines) > 3:
+            raise ValueError(f"A paragraph in phone script '{data.name}' had more than 3 lines:\n{paragraph}")
+        cmd = None
+        for line in lines:
+            if cmd is None:
+                cmd = text_cmd if not script_lines else para_cmd
+            elif cmd == text_cmd or cmd == para_cmd:
+                cmd = line_cmd
+            elif cmd == line_cmd:
+                cmd = cont_cmd
+
+            try:
+                blocks = script_line_to_blocks(cmd, line)
+            except ValueError as ex:
+                raise ValueError(f"Error in phone script '{data.name}': {ex}") from ex
+            script_lines.append(ScriptLine(blocks))
+
+    script_lines.append(ScriptLine([done_cmd]))
+    return PhoneScript(caller, script_lines)
 
 
 def split_location(location_name):
@@ -151,552 +243,11 @@ def template_call_filler_hint(location, world):
     ])
 
 
-def get_shuffled_basic_calls(random):
-    basic_calls = copy.deepcopy(phone_scripts)
+def get_shuffled_basic_calls(random, phone_scripts) -> List[PhoneScript]:
+    basic_calls = []
+    for phone_data in phone_scripts:
+        basic_calls.append(data_to_script(phone_data))
     random.shuffle(basic_calls)
     return basic_calls
 
-
-# IMPORTANT #
-# Before adding your phone trap please read ./docs/phone_data.md
-
-ffxiv = PhoneScript(caller_withheld, [
-    ScriptLine([text_cmd, "Hi, ", play_g_cmd, "!"]),
-    ScriptLine([para_cmd, "Have you heard of"]),
-    ScriptLine([line_cmd, "the critically"]),
-    ScriptLine([para_cmd, "acclaimed MMORPG"]),
-    ScriptLine([line_cmd, "Final Fantasy XIV?"]),
-    ScriptLine([para_cmd, "With an expanded"]),
-    ScriptLine([line_cmd, "free trial which"]),
-    ScriptLine([para_cmd, "you can play"]),
-    ScriptLine([line_cmd, "through the"]),
-    ScriptLine([para_cmd, "entirety of A"]),
-    ScriptLine([line_cmd, "Realm Reborn and"]),
-    ScriptLine([para_cmd, "the award-winning"]),
-    ScriptLine([line_cmd, "Heavensward"]),
-    ScriptLine([para_cmd, "expansion"]),
-    ScriptLine([line_cmd, "and also the"]),
-    ScriptLine([para_cmd, "award-winning"]),
-    ScriptLine([line_cmd, "Stormblood"]),
-    ScriptLine([para_cmd, "expansion"]),
-    ScriptLine([line_cmd, "up to Lv.70 for"]),
-    ScriptLine([para_cmd, "free with no"]),
-    ScriptLine([line_cmd, "restrictions on"]),
-    ScriptLine([para_cmd, "playtime?"]),
-    ScriptLine([para_cmd, "Play today!"]),
-    ScriptLine([done_cmd])
-])
-
-brock_oven = PhoneScript(caller_brock, [
-    ScriptLine([text_cmd, "Why do they"]),
-    ScriptLine([line_cmd, "call it OVEN…"]),
-    ScriptLine([para_cmd, "when you OF IN"]),
-    ScriptLine([line_cmd, "the COLD FOOD…"]),
-    ScriptLine([para_cmd, "OF OUT hot eat"]),
-    ScriptLine([line_cmd, "the FOOD?"]),
-    ScriptLine([para_cmd, "Really makes you"]),
-    ScriptLine([line_cmd, "think…"]),
-    ScriptLine([done_cmd])
-])
-
-gura_call = PhoneScript(caller_withheld, [
-    ScriptLine([text_cmd, "H-Hello ma'am…"]),
-    ScriptLine([para_cmd, "Do you have a"]),
-    ScriptLine([line_cmd, "moment to talk"]),
-    ScriptLine([para_cmd, "about our lord and"]),
-    ScriptLine([line_cmd, "savior LIGHTNING"]),
-    ScriptLine([cont_cmd, "MCQUEEN?"]),
-    ScriptLine([para_cmd, "He's the star of"]),
-    ScriptLine([line_cmd, "several feature"]),
-    ScriptLine([cont_cmd, "films, such as"]),
-    ScriptLine([para_cmd, "CARS, CARS 2,"]),
-    ScriptLine([line_cmd, "CARS 3, PLANES:"]),
-    ScriptLine([cont_cmd, "FIRE & RESCUE,"]),
-    ScriptLine([para_cmd, "FINDING DORY, TOY"]),
-    ScriptLine([line_cmd, "STORY 3, COCO,"]),
-    ScriptLine([para_cmd, "and RALPH BREAKS"]),
-    ScriptLine([line_cmd, "THE INTERNET,"]),
-    ScriptLine([para_cmd, "as well as other"]),
-    ScriptLine([line_cmd, "short films such"]),
-    ScriptLine([cont_cmd, "as-"]),
-    ScriptLine([para_cmd, "K-KINGDOM HEARTS?"]),
-    ScriptLine([done_cmd])
-])
-
-regi_call = PhoneScript(caller_withheld, [
-    ScriptLine([text_cmd, "REGIROCK: ÜN ÜN ÜN"]),
-    ScriptLine([line_cmd, "$Ae▶&!→ ,♀é▷Ö"]),
-    ScriptLine([para_cmd, "ÜN ÜN ÜN ÜN ÜN ÜN"]),
-    ScriptLine([line_cmd, "AAAAAAOOOOOOOORT"]),
-    ScriptLine([para_cmd, "REGISTEEL: 1001000"]),
-    ScriptLine([line_cmd, "1000101 1001100"]),
-    ScriptLine([cont_cmd, "1001100 1001111"]),
-    ScriptLine([done_cmd])
-])
-
-eusine_call = PhoneScript(caller_eusine, [
-    ScriptLine([text_cmd, "Hiya, ", play_g_cmd, "!"]),
-    ScriptLine([line_cmd, "It's EUSINE!"]),
-    ScriptLine([para_cmd, "I just wanted to"]),
-    ScriptLine([line_cmd, "call you about"]),
-    ScriptLine([para_cmd, "a discovery I"]),
-    ScriptLine([line_cmd, "made. A baby"]),
-    ScriptLine([cont_cmd, "SUICUNE!"]),
-    ScriptLine([para_cmd, "That's right, it's"]),
-    ScriptLine([line_cmd, "small and blue,"]),
-    ScriptLine([para_cmd, "large head with"]),
-    ScriptLine([line_cmd, "antennae of some"]),
-    ScriptLine([cont_cmd, "kind."]),
-    ScriptLine([para_cmd, "It has no arms,"]),
-    ScriptLine([line_cmd, "but somehow it"]),
-    ScriptLine([cont_cmd, "learned ICE PUNCH!"]),
-    ScriptLine([done_cmd])
-])
-
-slowpoke_call = PhoneScript(caller_withheld, [
-    ScriptLine([text_cmd, "Hi, hello?"]),
-    ScriptLine([para_cmd, "I'm calling about"]),
-    ScriptLine([line_cmd, "an amazing invest-"]),
-    ScriptLine([cont_cmd, "ment opportunity:"]),
-    ScriptLine([para_cmd, "Just for you, a"]),
-    ScriptLine([line_cmd, "delicious, mouth-"]),
-    ScriptLine([para_cmd, "watering, tender"]),
-    ScriptLine([line_cmd, "SLOWPOKETAIL for"]),
-    ScriptLine([para_cmd, "the low low price"]),
-    ScriptLine([line_cmd, "of ¥1000000!"]),
-    ScriptLine([para_cmd, "Hello? Are you"]),
-    ScriptLine([line_cmd, "still there?"]),
-    ScriptLine([done_cmd])
-])
-
-elm_hacked_call = PhoneScript(caller_elm, [
-    ScriptLine([text_cmd, play_g_cmd, "?"]),
-    ScriptLine([line_cmd, "Oh it's terrible."]),
-    ScriptLine([para_cmd, "I got a call from"]),
-    ScriptLine([line_cmd, poke_cmd, "GEAR tech-"]),
-    ScriptLine([cont_cmd, "nical support,"]),
-    ScriptLine([para_cmd, "or so they said!"]),
-    ScriptLine([para_cmd, "They took my"]),
-    ScriptLine([line_cmd, "number, my"]),
-    ScriptLine([cont_cmd, poke_cmd, "PAY account,"]),
-    ScriptLine([para_cmd, "Gosh, even all my"]),
-    ScriptLine([line_cmd, "PRIMEAPES are gone"]),
-    ScriptLine([para_cmd, player_cmd, " got ELM's"]),
-    ScriptLine([line_cmd, "new phone number."]),
-    ScriptLine([para_cmd, "Whatever will I"]),
-    ScriptLine([line_cmd, "do…"]),
-    ScriptLine([done_cmd])
-])
-
-mom_password_call = PhoneScript(caller_mom, [
-    ScriptLine([text_cmd, "Hello?"]),
-    ScriptLine([para_cmd, "Hi ", play_g_cmd, "…"]),
-    ScriptLine([line_cmd, "I was going to"]),
-    ScriptLine([para_cmd, "buy something"]),
-    ScriptLine([line_cmd, "nice for you,"]),
-    ScriptLine([para_cmd, "but I accident-"]),
-    ScriptLine([line_cmd, "ally spent the"]),
-    ScriptLine([para_cmd, "money on BLUE"]),
-    ScriptLine([line_cmd, "CARD points."]),
-    ScriptLine([para_cmd, "I promise I'll"]),
-    ScriptLine([line_cmd, "make it up to you,"]),
-    ScriptLine([para_cmd, "but later,"]),
-    ScriptLine([line_cmd, "PASSWORD is"]),
-    ScriptLine([cont_cmd, "starting now!"]),
-    ScriptLine([done_cmd])
-])
-
-warranty_call = PhoneScript(caller_withheld, [
-    ScriptLine([text_cmd, "Hello, we're"]),
-    ScriptLine([line_cmd, "trying to reach"]),
-    ScriptLine([para_cmd, "you about your"]),
-    ScriptLine([line_cmd, "BICYCLE's ex-"]),
-    ScriptLine([cont_cmd, "tended warranty-"]),
-    ScriptLine([done_cmd])
-])
-
-bill_id_call = PhoneScript(caller_bill, [
-    ScriptLine([text_cmd, "Gugyoo…"]),
-    ScriptLine([line_cmd, "Guooh! Pijji!"]),
-    ScriptLine([para_cmd, "Ha! Fooled you!"]),
-    ScriptLine([line_cmd, "Those aren't "]),
-    ScriptLine([cont_cmd, poke_cmd, "MON"]),
-    ScriptLine([para_cmd, "It's actually me,"]),
-    ScriptLine([line_cmd, "BILL!"]),
-    ScriptLine([para_cmd, "Wh-You knew?"]),
-    ScriptLine([line_cmd, "Caller ID?"]),
-    ScriptLine([para_cmd, "Rats, foiled by my"]),
-    ScriptLine([line_cmd, "own invention"]),
-    ScriptLine([cont_cmd, "again"]),
-    ScriptLine([done_cmd])
-])
-
-elm_jsr_call = PhoneScript(caller_elm, [
-    ScriptLine([text_cmd, play_g_cmd, ", how are"]),
-    ScriptLine([line_cmd, "things going?"]),
-    ScriptLine([para_cmd, "I called because"]),
-    ScriptLine([line_cmd, "something weird is"]),
-    ScriptLine([para_cmd, "happening with the"]),
-    ScriptLine([line_cmd, "radio broadcasts."]),
-    ScriptLine([para_cmd, "They were talking"]),
-    ScriptLine([line_cmd, "about FUNKY FRESH"]),
-    ScriptLine([cont_cmd, "BEATS."]),
-    ScriptLine([para_cmd, "TEAM ROCKET must"]),
-    ScriptLine([line_cmd, "be running some"]),
-    ScriptLine([para_cmd, "kind of pirate"]),
-    ScriptLine([line_cmd, "radio station…"]),
-    ScriptLine([done_cmd])
-])
-
-bike_loyalty_call = PhoneScript(caller_bikeshop, [
-    ScriptLine([text_cmd, "Hiya ", play_g_cmd, "!"]),
-    ScriptLine([line_cmd, "We're calling"]),
-    ScriptLine([cont_cmd, "around"]),
-    ScriptLine([para_cmd, "to spread the word"]),
-    ScriptLine([line_cmd, "about our new"]),
-    ScriptLine([cont_cmd, "loyalty program!"]),
-    ScriptLine([para_cmd, "On your 10th"]),
-    ScriptLine([line_cmd, "purchase of any"]),
-    ScriptLine([cont_cmd, "BICYCLE, you get"]),
-    ScriptLine([para_cmd, "a BIKE VOUCHER,"]),
-    ScriptLine([line_cmd, "free of charge!"]),
-    ScriptLine([para_cmd, "We're also"]),
-    ScriptLine([line_cmd, "offering a "]),
-    ScriptLine([cont_cmd, "discount!"]),
-    ScriptLine([para_cmd, "A brand new"]),
-    ScriptLine([line_cmd, "BICYCLE for"]),
-    ScriptLine([cont_cmd, "¥999999.99!"]),
-    ScriptLine([done_cmd])
-])
-
-ppip_call = PhoneScript(caller_withheld, [
-    ScriptLine([text_cmd, "THIS IS AN AUTO-"]),
-    ScriptLine([line_cmd, "MATED MESSAGE"]),
-    ScriptLine([para_cmd, "FROM THE PORYGON"]),
-    ScriptLine([line_cmd, "POLITICAL"]),
-    ScriptLine([cont_cmd, "INTERESTS PARTY,"]),
-    ScriptLine([para_cmd, "OR P P I P FOR"]),
-    ScriptLine([line_cmd, "SHORT."]),
-    ScriptLine([para_cmd, "WE CAMPAIGN FOR"]),
-    ScriptLine([line_cmd, "PORYGON ISSUES,"]),
-    ScriptLine([cont_cmd, "PORYGON2 ISSUES"]),
-    ScriptLine([para_cmd, "AND ISSUES OF"]),
-    ScriptLine([line_cmd, "ANY OTHER POT-"]),
-    ScriptLine([cont_cmd, "ENTIAL PORYGON"]),
-    ScriptLine([para_cmd, "ISSUES SUCH AS:"]),
-    ScriptLine([para_cmd, "PENSIONS FOR"]),
-    ScriptLine([line_cmd, "VETERAN ELECTRIC"]),
-    ScriptLine([cont_cmd, "SOLDIERS,"]),
-    ScriptLine([para_cmd, "AND UNFAIR"]),
-    ScriptLine([line_cmd, "MALIGNMENT FOR THE"]),
-    ScriptLine([para_cmd, "UNFORTUNATE"]),
-    ScriptLine([line_cmd, "EVENTS OF 16. DEC"]),
-    ScriptLine([cont_cmd, "1997."]),
-    ScriptLine([para_cmd, "PLEASE VOTE FOR"]),
-    ScriptLine([line_cmd, "US IN THE UPCOMING"]),
-    ScriptLine([para_cmd, "JOHTO LOCAL"]),
-    ScriptLine([line_cmd, "ELECTIONS."]),
-    ScriptLine([done_cmd])
-])
-
-bill_eevee_call = PhoneScript(caller_bill, [
-    ScriptLine([text_cmd, "Hey ", play_g_cmd, "!"]),
-    ScriptLine([para_cmd, "I have just"]),
-    ScriptLine([line_cmd, "completed some"]),
-    ScriptLine([para_cmd, "research into"]),
-    ScriptLine([line_cmd, "EEVEE and its"]),
-    ScriptLine([cont_cmd, "evolutions!"]),
-    ScriptLine([para_cmd, "I have been able"]),
-    ScriptLine([line_cmd, "to scientif-"]),
-    ScriptLine([done_cmd])
-])
-
-elm_kyogre_call = PhoneScript(caller_elm, [
-    ScriptLine([text_cmd, "Hi, Mr. ", poke_cmd, "MON?"]),
-    ScriptLine([line_cmd, "Just following up"]),
-    ScriptLine([cont_cmd, "on your email."]),
-    ScriptLine([para_cmd, "The way I see it,"]),
-    ScriptLine([line_cmd, "KYOGRE is the one"]),
-    ScriptLine([cont_cmd, "surrounded!"]),
-    ScriptLine([para_cmd, "What's under the"]),
-    ScriptLine([line_cmd, "ocean? More"]),
-    ScriptLine([cont_cmd, "earth!"]),
-    ScriptLine([para_cmd, "Oh, ", play_g_cmd, "?!"]),
-    ScriptLine([line_cmd, "I must have called"]),
-    ScriptLine([cont_cmd, "the wrong number…"]),
-    ScriptLine([done_cmd])
-])
-
-elm_mew_call = PhoneScript(caller_elm, [
-    ScriptLine([text_cmd, "Oh… ", player_cmd, "…"]),
-    ScriptLine([para_cmd, "That red-headed"]),
-    ScriptLine([line_cmd, "kid came back"]),
-    ScriptLine([cont_cmd, "to the lab."]),
-    ScriptLine([para_cmd, "He said he would"]),
-    ScriptLine([line_cmd, "tell me where to"]),
-    ScriptLine([para_cmd, "find a rare ", poke_cmd, "-"]),
-    ScriptLine([line_cmd, "MON if I didn't"]),
-    ScriptLine([cont_cmd, "call the police."]),
-    ScriptLine([para_cmd, "Long story short,"]),
-    ScriptLine([line_cmd, "I've been pushing"]),
-    ScriptLine([para_cmd, "on this truck"]),
-    ScriptLine([line_cmd, "for hours now,"]),
-    ScriptLine([para_cmd, "and still no"]),
-    ScriptLine([line_cmd, "sight of the"]),
-    ScriptLine([cont_cmd, "thing…"]),
-    ScriptLine([done_cmd])
-])
-
-bank_of_mom_1 = PhoneScript(caller_bank_of_mom, [
-    ScriptLine([text_cmd, "Hello, ", play_g_cmd, "."]),
-    ScriptLine([line_cmd, "We're calling to"]),
-    ScriptLine([para_cmd, "let you know that"]),
-    ScriptLine([line_cmd, "your latest bank"]),
-    ScriptLine([para_cmd, "statement is now"]),
-    ScriptLine([line_cmd, "available online."]),
-    ScriptLine([para_cmd, "Thank you for"]),
-    ScriptLine([line_cmd, "managing your"]),
-    ScriptLine([cont_cmd, "finances with"]),
-    ScriptLine([para_cmd, "BANK of MOM."]),
-    ScriptLine([done_cmd])
-])
-
-bank_of_mom_2 = PhoneScript(caller_bank_of_mom, [
-    ScriptLine([text_cmd, "Hello, ", play_g_cmd, "."]),
-    ScriptLine([line_cmd, "We're calling to"]),
-    ScriptLine([para_cmd, "ask you about"]),
-    ScriptLine([line_cmd, "some suspicious"]),
-    ScriptLine([para_cmd, "transactions"]),
-    ScriptLine([line_cmd, "made with your"]),
-    ScriptLine([cont_cmd, "bank account."]),
-    ScriptLine([para_cmd, "Today there were"]),
-    ScriptLine([line_cmd, "3 purchases of"]),
-    ScriptLine([cont_cmd, "SUPER POTIONs"]),
-    ScriptLine([para_cmd, "from an unknown"]),
-    ScriptLine([line_cmd, "location."]),
-    ScriptLine([para_cmd, "Okay, we can"]),
-    ScriptLine([line_cmd, "unfreeze your"]),
-    ScriptLine([cont_cmd, "account."]),
-    ScriptLine([para_cmd, "Thank you for"]),
-    ScriptLine([line_cmd, "managing your"]),
-    ScriptLine([cont_cmd, "finances with"]),
-    ScriptLine([para_cmd, "BANK of MOM."]),
-    ScriptLine([done_cmd])
-])
-
-diglett_call = PhoneScript(caller_elm, [
-    ScriptLine([text_cmd, "Hi, ", play_g_cmd, "!"]),
-    ScriptLine([line_cmd, "I was doing some"]),
-    ScriptLine([cont_cmd, "research on"]),
-    ScriptLine([para_cmd, "DIGLETT and disc-"]),
-    ScriptLine([line_cmd, "covered something"]),
-    ScriptLine([cont_cmd, "remarkable!"]),
-    ScriptLine([para_cmd, "For ages, the"]),
-    ScriptLine([line_cmd, "underside of"]),
-    ScriptLine([cont_cmd, "DIGLETT and"]),
-    ScriptLine([para_cmd, "DUGTRIO have re-"]),
-    ScriptLine([line_cmd, "mained a mystery,"]),
-    ScriptLine([cont_cmd, "but I've finally"]),
-    ScriptLine([para_cmd, "figured it out!"]),
-    ScriptLine([line_cmd, "It took four"]),
-    ScriptLine([cont_cmd, "X-RAYS, twenty"]),
-    ScriptLine([para_cmd, "ultrasounds, a"]),
-    ScriptLine([line_cmd, "seismograph,"]),
-    ScriptLine([cont_cmd, "3 well timed"]),
-    ScriptLine([para_cmd, "photos, 100 cups"]),
-    ScriptLine([line_cmd, "of coffee,"]),
-    ScriptLine([cont_cmd, "and 2 assistants"]),
-    ScriptLine([para_cmd, "to finally find"]),
-    ScriptLine([line_cmd, "out th-- --lly--"]),
-    ScriptLine([para_cmd, "--llo? Breaking--"]),
-    ScriptLine([line_cmd, "--up? ", play_g_cmd, "?--"]),
-    ScriptLine([done_cmd])
-])
-
-team_rocket_call = PhoneScript(caller_withheld, [
-    ScriptLine([text_cmd, "Who are we, you"]),
-    ScriptLine([line_cmd, "ask?"]),
-    ScriptLine([para_cmd, "Prepare for"]),
-    ScriptLine([line_cmd, "trouble!"]),
-    ScriptLine([para_cmd, "Make it double!"]),
-    ScriptLine([para_cmd, "To protect the "]),
-    ScriptLine([line_cmd, "world from"]),
-    ScriptLine([cont_cmd, "devastation!"]),
-    ScriptLine([para_cmd, "To unite all"]),
-    ScriptLine([line_cmd, "peoples within our"]),
-    ScriptLine([cont_cmd, "nation!"]),
-    ScriptLine([para_cmd, "To denounce the"]),
-    ScriptLine([line_cmd, "evils of truth"]),
-    ScriptLine([cont_cmd, "and love!"]),
-    ScriptLine([para_cmd, "To extend our"]),
-    ScriptLine([line_cmd, "reach to the stars"]),
-    ScriptLine([cont_cmd, "above!"]),
-    ScriptLine([para_cmd, "JESSIE…"]),
-    ScriptLine([line_cmd, "JAMES…"]),
-    ScriptLine([para_cmd, "TEAM ROCKET blasts"]),
-    ScriptLine([line_cmd, "off at the speed"]),
-    ScriptLine([cont_cmd, "of light!"]),
-    ScriptLine([para_cmd, "Surrender now or"]),
-    ScriptLine([line_cmd, "prepare to fight!"]),
-    ScriptLine([para_cmd, "MEOWTH!"]),
-    ScriptLine([line_cmd, "That's right!"]),
-    ScriptLine([done_cmd])
-])
-
-happy_birthday = PhoneScript(caller_mom, [
-    ScriptLine([text_cmd, "Hi, ", play_g_cmd, "!"]),
-    ScriptLine([para_cmd, "Happy Birthday"]),
-    ScriptLine([line_cmd, "to you! Happy"]),
-    ScriptLine([cont_cmd, "Birthday to y-"]),
-    ScriptLine([para_cmd, "What do you mean"]),
-    ScriptLine([line_cmd, "it's not your"]),
-    ScriptLine([cont_cmd, "birthday? Is today"]),
-    ScriptLine([para_cmd, "not March 23rd?"]),
-    ScriptLine([line_cmd, "Oh, well,"]),
-    ScriptLine([cont_cmd, "nevermind then!"]),
-    ScriptLine([done_cmd])
-])
-
-lance_cape = PhoneScript(caller_withheld, [
-    ScriptLine([text_cmd, "Hello? LANCE?"]),
-    ScriptLine([para_cmd, "I wanted to let"]),
-    ScriptLine([line_cmd, "you know that your"]),
-    ScriptLine([cont_cmd, "new champion"]),
-    ScriptLine([para_cmd, "outfit can't"]),
-    ScriptLine([line_cmd, "include a cape,"]),
-    ScriptLine([cont_cmd, "dahling."]),
-    ScriptLine([para_cmd, "Not convinced?"]),
-    ScriptLine([line_cmd, "LEON! His cape"]),
-    ScriptLine([para_cmd, "gets so dirty, he"]),
-    ScriptLine([line_cmd, "has to clean it"]),
-    ScriptLine([para_cmd, "every day! CLAIR!"]),
-    ScriptLine([line_cmd, "Her DRAGONAIR"]),
-    ScriptLine([para_cmd, "sets it on fire"]),
-    ScriptLine([line_cmd, "all the time!"]),
-    ScriptLine([para_cmd, "And don't get me"]),
-    ScriptLine([line_cmd, "started on"]),
-    ScriptLine([para_cmd, "WALLACE! His"]),
-    ScriptLine([line_cmd, "gets soaked and"]),
-    ScriptLine([cont_cmd, "drags him down!"]),
-    ScriptLine([para_cmd, "…Huh? Oh!"]),
-    ScriptLine([line_cmd, "Wrong number!"]),
-    ScriptLine([done_cmd])
-])
-
-flareon_call = PhoneScript(caller_withheld, [
-    ScriptLine([text_cmd, "Hey, ", play_g_cmd, "!"]),
-    ScriptLine([para_cmd, "Did you know that"]),
-    ScriptLine([line_cmd, "in terms of human"]),
-    ScriptLine([para_cmd, "companionship,"]),
-    ScriptLine([line_cmd, "FLAREON is"]),
-    ScriptLine([para_cmd, "objectively the"]),
-    ScriptLine([line_cmd, "most huggable"]),
-    ScriptLine([cont_cmd, poke_cmd, "MON?"]),
-    ScriptLine([para_cmd, "While their max"]),
-    ScriptLine([line_cmd, "temperature is--"]),
-    ScriptLine([done_cmd])
-])
-
-blender_call = PhoneScript(caller_mom, [
-    ScriptLine([text_cmd, "Hello?"]),
-    ScriptLine([para_cmd, "Hi ", play_g_cmd, "!"]),
-    ScriptLine([line_cmd, "How have you been?"]),
-    ScriptLine([para_cmd, "Oh, wait! I should"]),
-    ScriptLine([line_cmd, "tell you what"]),
-    ScriptLine([cont_cmd, "I had for lunch!"]),
-    ScriptLine([para_cmd, "Remember when we"]),
-    ScriptLine([line_cmd, "got Subway last"]),
-    ScriptLine([cont_cmd, "week?"]),
-    ScriptLine([para_cmd, "Well, I put it in"]),
-    ScriptLine([line_cmd, "a blender and"]),
-    ScriptLine([cont_cmd, "ate it!"]),
-    ScriptLine([para_cmd, "It was so good!"]),
-    ScriptLine([para_cmd, "Hello?"]),
-    ScriptLine([line_cmd, play_g_cmd, " are you"]),
-    ScriptLine([cont_cmd, "there?"]),
-    ScriptLine([done_cmd])
-])
-
-call_your_mother = PhoneScript(caller_withheld, [
-    ScriptLine([text_cmd, "Here's some"]),
-    ScriptLine([line_cmd, "advice…"]),
-    ScriptLine([para_cmd, "Brush your teeth,"]),
-    ScriptLine([line_cmd, "be kind to to one"]),
-    ScriptLine([cont_cmd, "another"]),
-    ScriptLine([para_cmd, "Take 10 minutes to"]),
-    ScriptLine([line_cmd, "call your mother."]),
-    ScriptLine([para_cmd, "It's been three"]),
-    ScriptLine([line_cmd, "long weeks now,"]),
-    ScriptLine([para_cmd, "A text is not"]),
-    ScriptLine([line_cmd, "enough. You gotta"]),
-    ScriptLine([cont_cmd, "get on the phone,"]),
-    ScriptLine([para_cmd, "and give your"]),
-    ScriptLine([line_cmd, "mother a call!"]),
-    ScriptLine([para_cmd, "You gotta do what"]),
-    ScriptLine([line_cmd, "I say--!"]),
-    ScriptLine([done_cmd])
-])
-
-fuzz_call = PhoneScript(caller_out_of_area, [
-    ScriptLine([text_cmd, "................"]),
-    ScriptLine([line_cmd, "................"]),
-    ScriptLine([cont_cmd, "................"]),
-    ScriptLine([para_cmd, "................"]),
-    ScriptLine([line_cmd, "................"]),
-    ScriptLine([cont_cmd, "................"]),
-    ScriptLine([para_cmd, "..F............."]),
-    ScriptLine([line_cmd, "................"]),
-    ScriptLine([cont_cmd, "................"]),
-    ScriptLine([para_cmd, "................"]),
-    ScriptLine([line_cmd, "................"]),
-    ScriptLine([cont_cmd, "................"]),
-    ScriptLine([done_cmd])
-])
-
-daily_wowers_call = PhoneScript(caller_out_of_area, [
-    ScriptLine([text_cmd, "It's time for"]),
-    ScriptLine([line_cmd, "daily WOWers!"]),
-    ScriptLine([para_cmd, "chrisWOW chris-"]),
-    ScriptLine([line_cmd, "WOW chrisWOW"]),
-    ScriptLine([cont_cmd, "chrisWOW"]),
-    ScriptLine([para_cmd, "chrisWOW chris-"]),
-    ScriptLine([line_cmd, "WOW chrisWOW"]),
-    ScriptLine([cont_cmd, "chrisWOW"]),
-    ScriptLine([para_cmd, "WOWOWOWOWOWOW"]),
-    ScriptLine([line_cmd, "OWOWOWOWOWOWO"]),
-    ScriptLine([cont_cmd, "WOWOWOWOWOWOW"]),
-    ScriptLine([para_cmd, "OWOWOWOWOWOWO"]),
-    ScriptLine([line_cmd, "WOWOWOWOWOWOW"]),
-    ScriptLine([cont_cmd, "OWOW x247chWOW"]),
-    ScriptLine([done_cmd])
-])
-
-phone_scripts = [
-    ffxiv,
-    brock_oven,
-    gura_call,
-    regi_call,
-    eusine_call,
-    slowpoke_call,
-    elm_hacked_call,
-    mom_password_call,
-    warranty_call,
-    bill_id_call,
-    elm_jsr_call,
-    bike_loyalty_call,
-    ppip_call,
-    bill_eevee_call,
-    elm_kyogre_call,
-    elm_mew_call,
-    bank_of_mom_1,
-    bank_of_mom_2,
-    happy_birthday,
-    team_rocket_call,
-    lance_cape,
-    flareon_call,
-    blender_call,
-    call_your_mother,
-    diglett_call,
-    fuzz_call,
-    daily_wowers_call,
-]
+# Phone scripts now defined in ./data/phone_data.yaml

--- a/worlds/pokemon_crystal/test/test_phone_calls.py
+++ b/worlds/pokemon_crystal/test/test_phone_calls.py
@@ -1,5 +1,9 @@
+import yaml
+import pkgutil
+
 from test.bases import TestBase
-from ..phone_data import phone_scripts, poke_cmd
+from ..phone_data import poke_cmd, data_to_script
+from ..data import PhoneScriptData
 
 
 class PhoneCallsTest(TestBase):
@@ -7,7 +11,10 @@ class PhoneCallsTest(TestBase):
     max_line_length = 18
 
     def test_phone_calls(self):
-        for script in phone_scripts:
+        phone_scripts = yaml.safe_load(pkgutil.get_data("worlds.pokemon_crystal", "data/phone_data.yaml").decode('utf-8-sig'))
+
+        for script_name, script_data in phone_scripts.items():
+            script = data_to_script(PhoneScriptData(script_name, script_data.get("caller"), script_data.get("script")))
 
             assert len(script.get_script_bytes()) < self.max_phone_trap_bytes
 


### PR DESCRIPTION
<!--Thanks for contributing to the Pokémon Crystal Archipelago project!-->

## What does this add?
- Phone trap scripts are parsed from a YAML data file, and automatically create the necessary commands and calls to the pool without needing to manually mark each line.

## Why do you want it to be added?
- It should be easier to contribute phone trap scripts.
- Phone scripts are data, not logic, so are more appropriate to drive from input files instead of hard code.

## Was this tested yet?
- [x] Verified against the existing phone trap test.
- [x] Generated a world and encountered a phone trap pulled from file and verified it played as expected.
