### PR TITLE
feat: Add a new phone trap call script from Bill

### DIFF
--- a/worlds/pokemon_crystal/data/phone_data.yaml
+++ b/worlds/pokemon_crystal/data/phone_data.yaml
@@ -714,3 +714,41 @@ daily_wowers_call:
       OWOWOWOWOWOWO
       WOWOWOWOWOWOW
       OWOW x247chWOW
+
+
+bill_box:
+  caller: bill
+  script:
+    - |
+      Hi, <player>!
+    - |
+      We're implementing
+      a 100 <POKE>MON
+      storage limit 
+    - |
+      for the <POKE>MON
+      Storage System.
+    - |
+      Starting April 19,
+      all BOXES will
+      count towards a
+    - |
+      single 100-<POKE>MON
+      limit.
+    - |
+      Accounts over the
+      storage limit will
+      risk having
+    - |
+      their <POKE>MON
+      automatically
+      released.
+    - |
+      Less than 0.5
+      percent of active
+      trainers are over
+    - | 
+      the 100-<POKE>MON
+      storage limit
+      today.
+

--- a/worlds/pokemon_crystal/phone_data.py
+++ b/worlds/pokemon_crystal/phone_data.py
@@ -89,6 +89,7 @@ cmd_line_size = {
 def script_line_to_blocks(first_cmd: int, line: str):
     blocks = [first_cmd]
     size = 0
+    original_line = line
     while line:
         placeholder_start = line.find("<")
         placeholder_end = line.find(">", placeholder_start)
@@ -115,7 +116,7 @@ def script_line_to_blocks(first_cmd: int, line: str):
             size += len(line)
             break
     if size > 18:
-        raise ValueError(f"Line too long: '{line}' measured at {size} characters")
+        raise ValueError(f"Line too long: '{original_line}' measured at {size} characters")
 
     return blocks
 


### PR DESCRIPTION
<!--Thanks for contributing to the Pokémon Crystal Archipelago project!-->

## What does this add?
- A new phone trap script.

## Why do you want it to be added?
- We originally launched the Pokémon Storage System to help trainers create collections of their best Pokémon. However, Storage hasn't been very effective in driving discovery or engagement with trainers compared to features like Item Storage or Pokédex Evaluation. Despite low effectiveness, some trainers have accrued thousands of Pokémon over time.

## Was this tested yet?

```
$ pytest worlds/pokemon_crystal/test
============================= test session starts =============================
platform win32 -- Python 3.11.2, pytest-8.3.5, pluggy-1.5.0
rootdir: D:\code\Archipelago-Crystal
configfile: pytest.ini
plugins: subtests-0.14.1
collected 74 items

worlds\pokemon_crystal\test\test_hm_badges.py .......................... [ 35%]
.....................                                                    [ 63%]
worlds\pokemon_crystal\test\test_johto_only.py ..................        [ 87%]
worlds\pokemon_crystal\test\test_key_items.py ........                   [ 98%]
worlds\pokemon_crystal\test\test_phone_calls.py .                        [100%]

============================= 74 passed in 5.35s ==============================
```
![AP 42530671325215284472 P1 Dylie 2025-04-26 05 59 26](https://github.com/user-attachments/assets/8db183aa-3744-462d-af9c-aa2b4e4d7e8b)
