### PR TITLE
ruins of alph location name change plus one small extra

### DIFF
--- a/worlds/pokemon_crystal/data/locations.json
+++ b/worlds/pokemon_crystal/data/locations.json
@@ -3570,7 +3570,7 @@
     "script": "AP_NPC_TeamRocketBaseB2F_HM_WHIRLPOOL"
   },
   "HP_UP_FROM_VERMILION_GUY": {
-    "label": "Vermilion City - HP Up from Man by PokeCenter",
+    "label": "Vermilion City - HP Up from Man nowhere near PokeCenter",
     "flag": "EVENT_GOT_HP_UP_FROM_VERMILION_GUY",
     "type": "giveitem",
     "tags": [

--- a/worlds/pokemon_crystal/data/locations.json
+++ b/worlds/pokemon_crystal/data/locations.json
@@ -1672,7 +1672,7 @@
     "script": "Route9HiddenEther"
   },
   "PICKED_UP_ENERGY_ROOT_FROM_AERODACTYL_ITEM_ROOM": {
-    "label": "Ruins of Alph - Aerodactyl Room Item 1",
+    "label": "Ruins of Alph - Aerodactyl Top Right Room Item",
     "flag": "EVENT_PICKED_UP_ENERGY_ROOT_FROM_AERODACTYL_ITEM_ROOM",
     "type": "itemball",
     "tags": [
@@ -1682,7 +1682,7 @@
     "default_item": "ENERGY_ROOT"
   },
   "PICKED_UP_GOLD_BERRY_FROM_AERODACTYL_ITEM_ROOM": {
-    "label": "Ruins of Alph - Aerodactyl Room Item 2",
+    "label": "Ruins of Alph - Aerodactyl Room Bottom Left Item",
     "flag": "EVENT_PICKED_UP_GOLD_BERRY_FROM_AERODACTYL_ITEM_ROOM",
     "type": "itemball",
     "tags": [
@@ -1692,7 +1692,7 @@
     "default_item": "GOLD_BERRY"
   },
   "PICKED_UP_HEAL_POWDER_FROM_AERODACTYL_ITEM_ROOM": {
-    "label": "Ruins of Alph - Aerodactyl Room Item 3",
+    "label": "Ruins of Alph - Aerodactyl Top Left Room Item",
     "flag": "EVENT_PICKED_UP_HEAL_POWDER_FROM_AERODACTYL_ITEM_ROOM",
     "type": "itemball",
     "tags": [
@@ -1702,7 +1702,7 @@
     "default_item": "HEAL_POWDER"
   },
   "PICKED_UP_MOON_STONE_FROM_AERODACTYL_ITEM_ROOM": {
-    "label": "Ruins of Alph - Aerodactyl Room Item 4",
+    "label": "Ruins of Alph - Aerodactyl Bottom Right Room Item",
     "flag": "EVENT_PICKED_UP_MOON_STONE_FROM_AERODACTYL_ITEM_ROOM",
     "type": "itemball",
     "tags": [
@@ -1712,7 +1712,7 @@
     "default_item": "MOON_STONE"
   },
   "PICKED_UP_CHARCOAL_FROM_HO_OH_ITEM_ROOM": {
-    "label": "Ruins of Alph - Ho-Oh Room Item 1",
+    "label": "Ruins of Alph - Ho-Oh Room Top Right Item",
     "flag": "EVENT_PICKED_UP_CHARCOAL_FROM_HO_OH_ITEM_ROOM",
     "type": "itemball",
     "tags": [
@@ -1722,7 +1722,7 @@
     "default_item": "CHARCOAL"
   },
   "PICKED_UP_GOLD_BERRY_FROM_HO_OH_ITEM_ROOM": {
-    "label": "Ruins of Alph - Ho-Oh Room Item 2",
+    "label": "Ruins of Alph - Ho-Oh Room Bottom Left Item",
     "flag": "EVENT_PICKED_UP_GOLD_BERRY_FROM_HO_OH_ITEM_ROOM",
     "type": "itemball",
     "tags": [
@@ -1732,7 +1732,7 @@
     "default_item": "GOLD_BERRY"
   },
   "PICKED_UP_MYSTERYBERRY_FROM_HO_OH_ITEM_ROOM": {
-    "label": "Ruins of Alph - Ho-Oh Room Item 3",
+    "label": "Ruins of Alph - Ho-Oh Room Bottom Right Item",
     "flag": "EVENT_PICKED_UP_MYSTERYBERRY_FROM_HO_OH_ITEM_ROOM",
     "type": "itemball",
     "tags": [
@@ -1742,7 +1742,7 @@
     "default_item": "MYSTERYBERRY"
   },
   "PICKED_UP_REVIVAL_HERB_FROM_HO_OH_ITEM_ROOM": {
-    "label": "Ruins of Alph - Ho-Oh Room Item 4",
+    "label": "Ruins of Alph - Ho-Oh Room Top Left Item",
     "flag": "EVENT_PICKED_UP_REVIVAL_HERB_FROM_HO_OH_ITEM_ROOM",
     "type": "itemball",
     "tags": [
@@ -1752,7 +1752,7 @@
     "default_item": "REVIVAL_HERB"
   },
   "PICKED_UP_BERRY_FROM_KABUTO_ITEM_ROOM": {
-    "label": "Ruins of Alph - Kabuto Room Item 1",
+    "label": "Ruins of Alph - Kabuto Room Bottom Left Item",
     "flag": "EVENT_PICKED_UP_BERRY_FROM_KABUTO_ITEM_ROOM",
     "type": "itemball",
     "tags": [
@@ -1762,7 +1762,7 @@
     "default_item": "BERRY"
   },
   "PICKED_UP_ENERGYPOWDER_FROM_KABUTO_ITEM_ROOM": {
-    "label": "Ruins of Alph - Kabuto Room Item 2",
+    "label": "Ruins of Alph - Kabuto Room Top Right Item",
     "flag": "EVENT_PICKED_UP_ENERGYPOWDER_FROM_KABUTO_ITEM_ROOM",
     "type": "itemball",
     "tags": [
@@ -1772,7 +1772,7 @@
     "default_item": "ENERGYPOWDER"
   },
   "PICKED_UP_HEAL_POWDER_FROM_KABUTO_ITEM_ROOM": {
-    "label": "Ruins of Alph - Kabuto Room Item 3",
+    "label": "Ruins of Alph - Kabuto Room Top Left Item",
     "flag": "EVENT_PICKED_UP_HEAL_POWDER_FROM_KABUTO_ITEM_ROOM",
     "type": "itemball",
     "tags": [
@@ -1782,7 +1782,7 @@
     "default_item": "HEAL_POWDER"
   },
   "PICKED_UP_PSNCUREBERRY_FROM_KABUTO_ITEM_ROOM": {
-    "label": "Ruins of Alph - Kabuto Room Item 4",
+    "label": "Ruins of Alph - Kabuto Room Bottom Right Item",
     "flag": "EVENT_PICKED_UP_PSNCUREBERRY_FROM_KABUTO_ITEM_ROOM",
     "type": "itemball",
     "tags": [
@@ -1792,7 +1792,7 @@
     "default_item": "PSNCUREBERRY"
   },
   "PICKED_UP_MYSTERYBERRY_FROM_OMANYTE_ITEM_ROOM": {
-    "label": "Ruins of Alph - Omanyte Room Item 1",
+    "label": "Ruins of Alph - Omanyte Bottom Left Room Item",
     "flag": "EVENT_PICKED_UP_MYSTERYBERRY_FROM_OMANYTE_ITEM_ROOM",
     "type": "itemball",
     "tags": [
@@ -1802,7 +1802,7 @@
     "default_item": "MYSTERYBERRY"
   },
   "PICKED_UP_MYSTIC_WATER_FROM_OMANYTE_ITEM_ROOM": {
-    "label": "Ruins of Alph - Omanyte Room Item 2",
+    "label": "Ruins of Alph - Omanyte Bottom Right Room Item",
     "flag": "EVENT_PICKED_UP_MYSTIC_WATER_FROM_OMANYTE_ITEM_ROOM",
     "type": "itemball",
     "tags": [
@@ -1812,7 +1812,7 @@
     "default_item": "MYSTIC_WATER"
   },
   "PICKED_UP_STAR_PIECE_FROM_OMANYTE_ITEM_ROOM": {
-    "label": "Ruins of Alph - Omanyte Room Item 3",
+    "label": "Ruins of Alph - Omanyte Room Top Right Item",
     "flag": "EVENT_PICKED_UP_STAR_PIECE_FROM_OMANYTE_ITEM_ROOM",
     "type": "itemball",
     "tags": [
@@ -1822,7 +1822,7 @@
     "default_item": "STAR_PIECE"
   },
   "PICKED_UP_STARDUST_FROM_OMANYTE_ITEM_ROOM": {
-    "label": "Ruins of Alph - Omanyte Room Item 4",
+    "label": "Ruins of Alph - Omanyte Room Top Left Item",
     "flag": "EVENT_PICKED_UP_STARDUST_FROM_OMANYTE_ITEM_ROOM",
     "type": "itemball",
     "tags": [

--- a/worlds/pokemon_crystal/rules.py
+++ b/worlds/pokemon_crystal/rules.py
@@ -752,7 +752,7 @@ def set_rules(world: "PokemonCrystalWorld") -> None:
         set_rule(get_entrance("REGION_VERMILION_CITY -> REGION_VERMILION_GYM"),
                  lambda state: can_cut(state) or can_surf(state))
 
-        set_rule(get_location("Vermilion City - HP Up from Man by PokeCenter"), lambda state: has_n_badges(state, 16))
+        set_rule(get_location("Vermilion City - HP Up from Man nowhere near PokeCenter"), lambda state: has_n_badges(state, 16))
 
         set_rule(get_location("Vermilion City - Lost Item from Guy in Fan Club"),
                  lambda state: state.has("EVENT_RESTORED_POWER_TO_KANTO", world.player) and state.has(


### PR DESCRIPTION
Ruins of alph items finally have proper names instead of numbers
And the space time continuum was fixed in Vermillion
Final change (for now)