### PR TITLE
Optimize get_random_colors and convert_color

### DIFF
--- a/worlds/pokemon_crystal/pokemon.py
+++ b/worlds/pokemon_crystal/pokemon.py
@@ -314,10 +314,10 @@ def get_random_types(random):
 
 # palettes stuff
 def get_random_colors(random):
-    colors = []
-    for i in range(4):  # 2 normal colors, 2 shiny colors
-        colors += convert_color(random.randint(0, 31), random.randint(0, 31), random.randint(0, 31))
-    return list(colors)
+    return [
+        c for c in convert_color(random.randint(0, 31), random.randint(0, 31), random.randint(0, 31))
+        for _ in range(4)
+    ]
 
 
 def get_type_colors(types, random):
@@ -347,10 +347,11 @@ def shift_color(r: int, g: int, b: int, random):
 
 
 def convert_color(r: int, g: int, b: int):
-    color = 0
-    color += sorted((0, r, 31))[1]
-    color += (sorted((0, g, 31))[1] << 5)
-    color += (sorted((0, b, 31))[1] << 10)
+    r = max(0, min(r, 31))
+    g = max(0, min(g, 31))
+    b = max(0, min(b, 31))
+
+    color = (b << 10) | (g << 5) | r
     return color.to_bytes(2, "little")
 
 


### PR DESCRIPTION
First, `get_random_colors`. List comprehensions are way faster
because you don't need to allocate the list multiple times.
For a million calls, it goes from 4.1s to 1.2s.

For `convert_color`, `sorted` actually allocates a list every time
whereas max/min is basic arithmetic. Using max/min is also way more
readable in what the code is actually doing (it took me a while to even
understand why it was sorting anything...). On its own, it makes
a million `get_type_colors` go from 4s to 3.44s.

With both those changes, it goes from 4.1s to 1.04s.

Worth noting that I checked that `convert_color` returns the exact same
thing for all values of rgb between -10 and 255 for each component.

```
get_random_colors | convert_color

old | old
4.116109441965818

old | new
3.4419355569407344

new | old
1.2401713710278273

new | new
1.043951882980764
```