### PR TITLE
Fix logging with a raw `%` in the message

### DIFF
--- a/worlds/pokemon_crystal/utils.py
+++ b/worlds/pokemon_crystal/utils.py
@@ -214,7 +214,7 @@ def adjust_options(world: "PokemonCrystalWorld"):
         world.options.hm_compatibility.value = 100
         logging.warning(
             "Randomize starting town is enabled. "
-            "Setting HM Compatibility to 100% for player %s.",
+            "Setting HM Compatibility to 100%% for player %s.",
             world.multiworld.get_player_name(world.player)
         )
     # In race mode we don't patch any item location information into the ROM


### PR DESCRIPTION
`%` is a special character for the logger library that it uses to format the message. With `100% ` it gets a bit confused so you have to escape it by doubling it otherwise you get:

```
--- Logging error ---
Traceback (most recent call last):
  File "/home/eijebong/.local/share/uv/python/cpython-3.11.11-linux-x86_64-gnu/lib/python3.11/logging/__init__.py", line 1110, in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "/home/eijebong/.local/share/uv/python/cpython-3.11.11-linux-x86_64-gnu/lib/python3.11/logging/__init__.py", line 953, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "/home/eijebong/.local/share/uv/python/cpython-3.11.11-linux-x86_64-gnu/lib/python3.11/logging/__init__.py", line 687, in format
    record.message = record.getMessage()
                     ^^^^^^^^^^^^^^^^^^^
  File "/home/eijebong/.local/share/uv/python/cpython-3.11.11-linux-x86_64-gnu/lib/python3.11/logging/__init__.py", line 377, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: must be real number, not str

<snip...>

  File "/home/eijebong/code/ap-crystal/worlds/pokemon_crystal/__init__.py", line 171, in generate_early
    adjust_options(self)
  File "/home/eijebong/code/ap-crystal/worlds/pokemon_crystal/utils.py", line 215, in adjust_options
    logging.warning(
Message: 'Randomize starting town is enabled. Setting HM Compatibility to 100% for player %s.'
```
