### PR TITLE
New Phone trap: Team Headbuttrees!

### DIFF
--- a/worlds/pokemon_crystal/data/phone_data.yaml
+++ b/worlds/pokemon_crystal/data/phone_data.yaml
@@ -873,3 +873,36 @@ weast_call:
       DIGLETT'S CAVE,
     - |
       then you need t--
+
+headbutt_call:
+  caller: withheld
+  script:
+    - |
+      Hey guys!
+      It's MR. <POKE>MON!
+    - |
+      I'm here at
+      Route 26 with
+      Team Headbuttrees
+    - |
+      to plant NEW
+      HEADBUTT TREES!
+    - |
+      That's right, we
+      want to help the
+    - |
+      local sleeping
+      Pokémon
+      population!
+    - |
+      So remember to
+      send money to your
+    - |
+      mother so we can
+      continue to help
+      the planet!
+    - |
+      Every donation
+      helps!
+    - |
+      Peace out.


### PR DESCRIPTION
Thanks for contributing to the Pokémon Crystal Archipelago project!

## What does this add?
Another new phone trap! Made by Palex with an idea or two shot by me.
It's in reference to Mr. Beast's Team Trees campaign, well, as much as possible. It's also in reference to the headbutt trees being added to the map for wild encounters coming up.


## Why do you want it to be added?
It's a fun reference to upcoming features.

## Was this tested yet?
Nope!