### PR TITLE
Typo fix in the Headbutt trees phone trap fixed

### DIFF
--- a/worlds/pokemon_crystal/data/phone_data.yaml
+++ b/worlds/pokemon_crystal/data/phone_data.yaml
@@ -892,7 +892,7 @@ headbutt_call:
       want to help the
     - |
       local sleeping
-      Pokémon
+      <POKE>MON
       population!
     - |
       So remember to


### PR DESCRIPTION
## What does this add?
I umm forgot to change Pokémon to <POKE>MON. Oops! Glad that still compiles and all, but it's a good idea to be consistent.
