### PR TITLE
Fix random colors returning bytes in the wrong order

### DIFF
--- a/worlds/pokemon_crystal/pokemon.py
+++ b/worlds/pokemon_crystal/pokemon.py
@@ -393,8 +393,8 @@ def get_random_types(random):
 # palettes stuff
 def get_random_colors(random):
     return [
-        c for c in convert_color(random.randint(0, 31), random.randint(0, 31), random.randint(0, 31))
-        for _ in range(4)
+        c for _ in range(4)
+        for c in convert_color(random.randint(0, 31), random.randint(0, 31), random.randint(0, 31))
     ]
 
 


### PR DESCRIPTION
```py
def get_random_colors(random):
    return [
        c for _ in range(4) for c in b"AB"
    ]

def old_get_random_colors(random):
    return [
        c for c in b"AB" for _ in range(4)
    ]

r = random.Random()
print(get_random_colors(r))
print(old_get_random_colors(r))
```

```
[65, 66, 65, 66, 65, 66, 65, 66]
[65, 65, 65, 65, 66, 66, 66, 66]
```