### PR TITLE
Check if evolution method is enabled on the later evolutions of a line too

### DIFF
--- a/worlds/pokemon_crystal/pokemon.py
+++ b/worlds/pokemon_crystal/pokemon.py
@@ -263,7 +263,8 @@ def generate_evolution_data(world: "PokemonCrystalWorld"):
             if evolution_in_logic(world, evo):
                 evolution_pokemon.add(evo.pokemon)
                 for second_evo in world.generated_pokemon[evo.pokemon].evolutions:
-                    evolution_pokemon.add(second_evo.pokemon)
+                    if evolution_in_logic(world, second_evo):
+                        evolution_pokemon.add(second_evo.pokemon)
 
     world.logically_available_pokemon.update(evolution_pokemon)
 

--- a/worlds/pokemon_crystal/pokemon.py
+++ b/worlds/pokemon_crystal/pokemon.py
@@ -258,13 +258,15 @@ def generate_breeding_data(world: "PokemonCrystalWorld"):
 def generate_evolution_data(world: "PokemonCrystalWorld"):
     evolution_pokemon = set()
 
-    for pokemon in world.logically_available_pokemon:
-        for evo in world.generated_pokemon[pokemon].evolutions:
+    def recursive_evolution_add(evolving_pokemon):
+        for evo in world.generated_pokemon[evolving_pokemon].evolutions:
             if evolution_in_logic(world, evo):
                 evolution_pokemon.add(evo.pokemon)
-                for second_evo in world.generated_pokemon[evo.pokemon].evolutions:
-                    if evolution_in_logic(world, second_evo):
-                        evolution_pokemon.add(second_evo.pokemon)
+                recursive_evolution_add(evo.pokemon)
+        return
+
+    for pokemon in world.logically_available_pokemon:
+        recursive_evolution_add(pokemon)
 
     world.logically_available_pokemon.update(evolution_pokemon)
 


### PR DESCRIPTION
## What does this add?
Fixes an oversight where evolution lines where only the first Pokemon is logically available would not check if the 2nd -> 3rd evolution methods were enabled for logic in the options.
I made it a recursive method because i am looking into making randomized evolution that could allow longer evolution lines.

## Why do you want it to be added?
Bugfix

## Was this tested yet?
Only unit test