### PR TITLE
Add randomized Pokémon data to spoiler log and implement extend_hint_information for Dexsanity checks

### DIFF
--- a/worlds/pokemon_crystal/__init__.py
+++ b/worlds/pokemon_crystal/__init__.py
@@ -717,6 +717,11 @@ class PokemonCrystalWorld(World):
                    ):
                     continue
                 friendly_region_name = key.friendly_region_name()
+                if MiscOption.WhirlDexLocations in self.generated_misc.selected and friendly_region_name.startswith("Whirl"):
+                    friendly_region_name = friendly_region_name.replace(" N" if " N" in friendly_region_name else " S",
+                                                                        " S" if " N" in friendly_region_name else " N") \
+                                                               .replace("W " if "W " in friendly_region_name else "E ",
+                                                                        "E " if "W " in friendly_region_name else "W ")
                 for encounter in encounters:
                     if encounter.pokemon not in self.generated_dexsanity:
                         continue

--- a/worlds/pokemon_crystal/__init__.py
+++ b/worlds/pokemon_crystal/__init__.py
@@ -13,7 +13,7 @@ from worlds.AutoWorld import World, WebWorld
 from .client import PokemonCrystalClient
 from .data import PokemonData, TrainerData, MiscData, TMHMData, data as crystal_data, StaticPokemon, \
     MusicData, MoveData, FlyRegion, TradeData, MiscOption, APWORLD_VERSION, POKEDEX_OFFSET, StartingTown, \
-    LogicalAccess, EncounterKey, EncounterMon, MartData, EvolutionType
+    LogicalAccess, EncounterType, EncounterKey, EncounterMon, MartData, EvolutionType
 from .evolution import randomize_evolution
 from .items import PokemonCrystalItem, create_item_label_to_code_map, get_item_classification, ITEM_GROUPS, \
     item_const_name_to_id, item_const_name_to_label, adjust_item_classifications, get_random_filler_item, \
@@ -37,7 +37,7 @@ from .rom import generate_output, PokemonCrystalProcedurePatch
 from .rules import set_rules, PokemonCrystalLogic, verify_hm_accessibility
 from .trainers import boost_trainer_pokemon, randomize_trainers, vanilla_trainer_movesets
 from .utils import get_free_fly_locations, get_random_starting_town, \
-    adjust_options
+    adjust_options, evolution_in_logic
 from .wild import randomize_wild_pokemon, randomize_static_pokemon
 
 
@@ -635,6 +635,37 @@ class PokemonCrystalWorld(World):
         if self.options.randomize_starting_town:
             spoiler_handle.write(f"Starting Town: {self.starting_town.name}\n")
 
+        encounters_per_pokemon = None
+        if self.options.randomize_wilds:
+            encounters_per_pokemon = dict()
+            for key, encounters in self.generated_wild.items():
+                if key.encounter_type == EncounterType.Fish and key.region_id.startswith("Remoraid"):
+                    # The Remoraid table is only for GS, not Crystal
+                    continue
+                friendly_region_name = key.friendly_region_name()
+                for encounter in encounters:
+                    if encounter.pokemon not in encounters_per_pokemon.keys():
+                        encounters_per_pokemon[encounter.pokemon] = [friendly_region_name]
+                    else:
+                        encounters_per_pokemon[encounter.pokemon].append(friendly_region_name)
+        if self.options.randomize_static_pokemon:
+            if encounters_per_pokemon is None:
+                encounters_per_pokemon = dict()
+            for key, static in self.generated_static.items():
+                if static.level_type == "ignore":
+                    continue
+                if static.pokemon not in encounters_per_pokemon.keys():
+                    encounters_per_pokemon[static.pokemon] = [key.friendly_region_name()]
+                else:
+                    encounters_per_pokemon[static.pokemon].append(key.friendly_region_name())
+        if encounters_per_pokemon is not None:
+            spoiler_handle.write("\nRandomized Pokemon:\n")
+            lines = [f"{self.generated_pokemon[pokemon_id].friendly_name}: {', '.join(locations)}\n"
+                     for pokemon_id, locations in encounters_per_pokemon.items()]
+            lines.sort()
+            for line in lines:
+                spoiler_handle.write(line)
+
         if self.options.randomize_evolution:
             spoiler_handle.write("\nEvolutions:\n")
             for pokemon_id, evo_data in self.spoiler_evolutions.items():
@@ -675,6 +706,59 @@ class PokemonCrystalWorld(World):
         if self.options.enable_mischief:
             spoiler_handle.write(f"\nMischief:\n")
             get_misc_spoiler_log(self, spoiler_handle.write)
+
+    def extend_hint_information(self, hint_data: dict[int, dict[int, str]]):
+
+        def get_dexsanity_wild_hint_data(dexsanity_hint_data: dict[str, list[str]]):
+            for key, encounters in self.generated_wild.items():
+                if (self.logic.wild_regions[key] is not LogicalAccess.InLogic) or \
+                   (key.encounter_type == EncounterType.Fish and \
+                       (key.region_id.startswith("Remoraid") or key.region_id.endswith("_Swarm"))
+                   ):
+                    continue
+                friendly_region_name = key.friendly_region_name()
+                for encounter in encounters:
+                    if encounter.pokemon not in self.generated_dexsanity:
+                        continue
+                    if encounter.pokemon not in dexsanity_hint_data.keys():
+                        dexsanity_hint_data[encounter.pokemon] = [friendly_region_name]
+                    else:
+                        dexsanity_hint_data[encounter.pokemon].append(friendly_region_name)
+
+        def get_dexsanity_static_hint_data(dexsanity_hint_data: dict[str, list[str]]):
+            for key, static in self.generated_static.items():
+                if static.level_type == "ignore" or key.region_id in ["Entei", "Raikou"]:
+                    continue
+                friendly_region_name = key.friendly_region_name()
+                if static.pokemon not in self.generated_dexsanity:
+                    continue
+                if static.pokemon not in dexsanity_hint_data.keys():
+                    dexsanity_hint_data[static.pokemon] = [friendly_region_name]
+                else:
+                    dexsanity_hint_data[static.pokemon].append(friendly_region_name)
+
+        def get_dexsanity_evolution_hint_data(dexsanity_hint_data: dict[str, list[str]]):
+            for pokemon_id, pokemon_data in self.generated_pokemon.items():
+                for evo in pokemon_data.evolutions:
+                    if evolution_in_logic(self, evo):
+                        if evo.pokemon not in dexsanity_hint_data.keys():
+                            dexsanity_hint_data[evo.pokemon] = [f"Evolve {self.generated_pokemon[pokemon_id].friendly_name}"]
+                        else:
+                            dexsanity_hint_data[evo.pokemon].append(f"Evolve {self.generated_pokemon[pokemon_id].friendly_name}")
+
+        player_hint_data = dict()
+        if self.options.dexsanity:
+            dexsanity_hint_data = dict()
+            if self.options.randomize_wilds:
+                get_dexsanity_wild_hint_data(dexsanity_hint_data)
+            if self.options.randomize_static_pokemon and self.options.static_pokemon_required:
+                get_dexsanity_static_hint_data(dexsanity_hint_data)
+            if self.options.randomize_evolution:
+                get_dexsanity_evolution_hint_data(dexsanity_hint_data)
+            player_hint_data |= {self.location_name_to_id[f"Pokedex - {self.generated_pokemon[pokemon_id].friendly_name}"]: ", ".join(methods)
+                                 for pokemon_id, methods in dexsanity_hint_data.items()}
+
+        hint_data[self.player] = player_hint_data
 
     def create_item(self, name: str) -> PokemonCrystalItem:
         return self.create_item_by_code(self.item_name_to_id[name])

--- a/worlds/pokemon_crystal/data.py
+++ b/worlds/pokemon_crystal/data.py
@@ -485,21 +485,47 @@ class EncounterKey:
             elif self.encounter_type is EncounterType.Static:
                 return f"{pretty_region} (Static)"
         elif self.encounter_type is EncounterType.Fish:
-            fishing_spot = self.region_id.replace("Whirl", "Whirl ") \
-                                         .replace("Gyarados", "Lake of Rage") \
-                                         .replace("Dratini_2", "Route 45") \
-                                         .replace("Dratini", "Dragon's Den") \
-                                         .replace("Qwilfish", "Routes 12, 13, 32") \
-                                         .replace("_Swarm", " (Swarm)")
+            replacement_table = {
+                "WhirlIslands": "Whirl Islands",
+                "Gyarados": "Lake of Rage",
+                "Dratini": "Dragon's Den",
+                "Dratini_2": "Route 45",
+                "Qwilfish": "Routes 12, 13, 32",
+                "Qwilfish_Swarm": "Routes 12, 13, 32 (Swarm)"
+            }
+            fishing_spot = replacement_table[self.region_id] if self.region_id in replacement_table.keys() else self.region_id
             return f"{fishing_spot} ({str(self.fishing_rod)} Rod)"
         elif self.encounter_type is EncounterType.Tree:
             return f"{self.region_id} Headbutt Trees ({str(self.rarity)})"
         elif self.encounter_type is EncounterType.Static:
-            spaced_name = self.region_id[0]
-            for char in self.region_id[1:]:
-                spaced_name += f" {char}" if char.isupper() or char.isdigit() else char
-            return spaced_name.replace("H Q", "HQ") \
-                              .replace("_ ", "-") # Ho-Oh
+            replacement_table = {
+                "UnionCaveLapras": "Union Cave B2F (Static)",
+                "EggTogepi": "Violet City (Egg from Aide)",
+                "OddEgg": "Route 34 (Odd Egg)",
+                "RocketHQTrap": "Rocket HQ (Trap)",
+                "RocketHQElectrode": "Rocket HQ (Electrode)",
+                "RedGyarados": "Lake of Rage (Static)",
+                "Ho_Oh": "Tin Tower Roof (Static)",
+                "Suicune": "Tin Tower 1F (Static)",
+                "Lugia": "Whirl Islands Lugia Chamber (Static)",
+                "Raikou": "Roaming",
+                "Entei": "Roaming",
+                "Sudowoodo": "Route 36 (Weird Tree)",
+                "Snorlax": "Vermilion City (Static)",
+                "CatchTutorial": "Catch Tutorial",
+                "Kenya": "Route 35 (Gift from Guard)",
+                "Celebi": "Ilex Forest (Shrine)",
+                "Shuckie": "Cianwood City (Gift from Mania)",
+                "Dratini": "Dragon's Den B1F (Gift from Elder)",
+                "Eevee": "Goldenrod City (Gift from Bill)",
+                "Tyrogue": "Mount Mortar B1F (Gift from Kiyo)",
+                "GoldenrodGameCorner": "Goldenrod Game Corner (Prize)",
+                "CeladonGameCornerPrizeRoom": "Celadon Game Corner (Prize)"
+            }
+            for key in [self.region_id, self.region_id[:-1]]:
+                if key in replacement_table.keys():
+                    return replacement_table[key]
+            raise ValueError(f"Invalid static type: {self.region_id}")
         elif self.encounter_type is EncounterType.RockSmash:
             return "Rock Smash"
         else:

--- a/worlds/pokemon_crystal/data.py
+++ b/worlds/pokemon_crystal/data.py
@@ -354,6 +354,7 @@ class MiscOption(IntEnum):
     MomItems = 10
     IcePath = 11
     TooManyDogs = 12
+    WhirlDexLocations = 13
 
     @staticmethod
     def all():

--- a/worlds/pokemon_crystal/data.py
+++ b/worlds/pokemon_crystal/data.py
@@ -465,6 +465,45 @@ class EncounterKey:
         else:
             raise ValueError(f"Invalid encounter type: {self.encounter_type}")
 
+    def friendly_region_name(self):
+        if (self.encounter_type is EncounterType.Grass
+                or self.encounter_type is EncounterType.Water):
+            from re import search
+            # Replace underscores with spaces, capitalize every word that isn't a floor or a cardinal direction
+            pretty_region = " ".join([word.capitalize() if search("^(B?\\d+F|[NS][EW])$", word) is None else word
+                                     for word in self.region_id.split("_")])
+            pretty_region = pretty_region.replace("Digletts", "Diglett's") \
+                                         .replace("Dragons", "Dragon's") \
+                                         .replace(" Of ", " of ")
+            if pretty_region.startswith("Whirl"):
+                pretty_region = pretty_region.replace("Island", "Islands")
+            if self.encounter_type is EncounterType.Grass:
+                return f"{pretty_region} (Land)"
+            elif self.encounter_type is EncounterType.Water:
+                return f"{pretty_region} (Surf)"
+            elif self.encounter_type is EncounterType.Static:
+                return f"{pretty_region} (Static)"
+        elif self.encounter_type is EncounterType.Fish:
+            fishing_spot = self.region_id.replace("Whirl", "Whirl ") \
+                                         .replace("Gyarados", "Lake of Rage") \
+                                         .replace("Dratini_2", "Route 45") \
+                                         .replace("Dratini", "Dragon's Den") \
+                                         .replace("Qwilfish", "Routes 12, 13, 32") \
+                                         .replace("_Swarm", " (Swarm)")
+            return f"{fishing_spot} ({str(self.fishing_rod)} Rod)"
+        elif self.encounter_type is EncounterType.Tree:
+            return f"{self.region_id} Headbutt Trees ({str(self.rarity)})"
+        elif self.encounter_type is EncounterType.Static:
+            spaced_name = self.region_id[0]
+            for char in self.region_id[1:]:
+                spaced_name += f" {char}" if char.isupper() or char.isdigit() else char
+            return spaced_name.replace("H Q", "HQ") \
+                              .replace("_ ", "-") # Ho-Oh
+        elif self.encounter_type is EncounterType.RockSmash:
+            return "Rock Smash"
+        else:
+            raise ValueError(f"Invalid encounter type: {self.encounter_type}")
+
     @staticmethod
     def grass(region_id: str, time_of_day: GrassTimeOfDay = GrassTimeOfDay.Day):
         return EncounterKey(EncounterType.Grass, region_id, time_of_day=time_of_day)

--- a/worlds/pokemon_crystal/misc.py
+++ b/worlds/pokemon_crystal/misc.py
@@ -14,6 +14,11 @@ def randomize_mischief(world: "PokemonCrystalWorld"):
     # Decide which mischief is active
     all_mischief = world.generated_misc.selected
 
+    if not world.options.dexsanity or ("Land" not in world.options.wild_encounter_methods_required and \
+                                       "Surfing" not in world.options.wild_encounter_methods_required):
+        # Don't waste a mischief slot if this can't be experienced
+        all_mischief.remove(MiscOption.WhirlDexLocations)
+
     lower_count = len(all_mischief) // 2
     upper_count = floor(len(all_mischief) * 0.75)
     mischief_count = world.random.randint(lower_count, upper_count)

--- a/worlds/pokemon_crystal/misc.py
+++ b/worlds/pokemon_crystal/misc.py
@@ -14,8 +14,9 @@ def randomize_mischief(world: "PokemonCrystalWorld"):
     # Decide which mischief is active
     all_mischief = world.generated_misc.selected
 
-    if not world.options.dexsanity or ("Land" not in world.options.wild_encounter_methods_required and \
-                                       "Surfing" not in world.options.wild_encounter_methods_required):
+    if MiscOption.WhirlDexLocations in all_mischief and \
+       (not world.options.dexsanity or ("Land" not in world.options.wild_encounter_methods_required and \
+                                        "Surfing" not in world.options.wild_encounter_methods_required)):
         # Don't waste a mischief slot if this can't be experienced
         all_mischief.remove(MiscOption.WhirlDexLocations)
 


### PR DESCRIPTION
Thanks for contributing to the Pokémon Crystal Archipelago project!

## What does this add?
This adds the list of all encounter methods to the spoiler generation (except Remoraid's fishing table and the catch tutorial, as they are useless to the player), and implements `extend_hint_information` for Dexsanity checks for randomized statics, randomized wilds, and evolutions (but not breeding) for showing in the client.
Adds `EncounterKey.friendly_region_name` for the legibility of it all

The spoiler will always have everything, but the hint data will only show in-logic methods.

Also, *:3*

## Why do you want it to be added?
People asked for it

## Was this tested yet?
Yes