### PR TITLE
Field Move Rework: Add Always Usable option and Docs

### DIFF
--- a/worlds/pokemon_crystal/docs/en_Pokemon Crystal.md
+++ b/worlds/pokemon_crystal/docs/en_Pokemon Crystal.md
@@ -26,7 +26,7 @@ Some changes have been made to the base game for this randomizer:
     - HM05 Flash - Boulder Badge
     - HM06 Whirlpool - Volcano Badge
     - HM07 Waterfall - Earth Badge
-- An in-game option for not requiring Field Moves to be taught was added. To keep Fly, Flash, and other Field Moves accessible, an additional menu is accessible by pressing Select on the Start Menu.
+- An in-game option for not requiring Field Moves to be taught was added. To keep Fly, Flash, and other Field Moves accessible, an additional menu is made available by pressing Select on the Start Menu.
 - Tin Tower 1F is accessible once you obtain the Clear Bell.
 - Tin Tower 2F+ is accessible once the aforementioned condition is met, and you have the Rainbow Wing. Both are items in
   the multiworld

--- a/worlds/pokemon_crystal/docs/en_Pokemon Crystal.md
+++ b/worlds/pokemon_crystal/docs/en_Pokemon Crystal.md
@@ -26,6 +26,7 @@ Some changes have been made to the base game for this randomizer:
     - HM05 Flash - Boulder Badge
     - HM06 Whirlpool - Volcano Badge
     - HM07 Waterfall - Earth Badge
+- An in-game option for not requiring Field Moves to be taught was added. To keep Fly, Flash, and other Field Moves accessible, an additional menu is accessible by pressing Select on the Start Menu.
 - Tin Tower 1F is accessible once you obtain the Clear Bell.
 - Tin Tower 2F+ is accessible once the aforementioned condition is met, and you have the Rainbow Wing. Both are items in
   the multiworld

--- a/worlds/pokemon_crystal/options.py
+++ b/worlds/pokemon_crystal/options.py
@@ -1089,6 +1089,16 @@ class HMPowerCap(NamedRange):
     }
 
 
+class FieldMovesAlwaysUsable(Toggle):
+    """
+    Decouples TM/HM Compatibility for Battle Moves and Field Moves.
+    If enabled, Field Moves will always be considered usable, regardless of TM or HM compatibility. Badge requirements still apply.
+
+    Ensure the "HMs Need Teaching" in-game option is also set to 'off' for this option to work as expected.
+    """
+    display_name = "Field Moves Always Usable"
+
+
 class RandomizeBaseStats(Choice):
     """
     - Vanilla: Vanilla base stats
@@ -1739,6 +1749,7 @@ class PokemonCrystalOptions(PerGameCommonOptions):
     tm_compatibility: TMCompatibility
     hm_compatibility: HMCompatibility
     hm_power_cap: HMPowerCap
+    field_moves_always_usable: FieldMovesAlwaysUsable
     randomize_base_stats: RandomizeBaseStats
     randomize_types: RandomizeTypes
     randomize_evolution: RandomizeEvolution
@@ -1843,6 +1854,7 @@ OPTION_GROUPS = [
          HMBadgeRequirements,
          RemoveBadgeRequirement,
          RequireFlash,
+         FieldMovesAlwaysUsable,
          FreeFlyLocation,
          FlyLocationBlocklist,
          EarlyFly,

--- a/worlds/pokemon_crystal/rom.py
+++ b/worlds/pokemon_crystal/rom.py
@@ -1008,6 +1008,11 @@ def generate_output(world: "PokemonCrystalWorld", output_directory: str, patch: 
     if world.options.require_flash == RequireFlash.option_hard_required:
         write_bytes(patch, [1], data.rom_addresses["AP_Setting_FlashHardRequired"] + 1)
 
+    if world.options.field_moves_always_usable:
+        write_bytes(patch, [1], data.rom_addresses["AP_Setting_FieldMovesAlwaysUsable_SetUp"] + 1)
+        write_bytes(patch, [1], data.rom_addresses["AP_Setting_FieldMovesAlwaysUsable_CallMove"] + 1)
+        write_bytes(patch, [1], data.rom_addresses["AP_Setting_FieldMovesAlwaysUsable_CheckTMHM"] + 1)
+
     if world.options.trainer_name:
         name_bytes = convert_to_ingame_text(world.options.trainer_name.value[:7])
         write_bytes(patch, name_bytes, data.rom_addresses["AP_Setting_DefaultTrainerName"])

--- a/worlds/pokemon_crystal/rules.py
+++ b/worlds/pokemon_crystal/rules.py
@@ -286,7 +286,7 @@ class PokemonCrystalLogic:
         required_items = {"TM02"}
         if not self.options.field_moves_always_usable:
             required_items.add("Teach HEADBUTT")
-        return lambda state: state.has_all(required_items, self.player
+        return lambda state: state.has_all(required_items, self.player)
 
     def can_rock_smash(self) -> CollectionRule:
         required_items = {"TM08"}

--- a/worlds/pokemon_crystal/rules.py
+++ b/worlds/pokemon_crystal/rules.py
@@ -233,42 +233,66 @@ class PokemonCrystalLogic:
 
     def can_cut(self, kanto: bool = False) -> CollectionRule:
         badge_requirement = self.has_hm_badge_requirement("CUT", kanto=kanto)
-        return lambda state: state.has_all(("HM01 Cut", "Teach CUT"), self.player) and badge_requirement(state)
+        required_items = {"HM01 Cut"}
+        if not self.options.field_moves_always_usable:
+            required_items.add("Teach CUT")
+        return lambda state: state.has_all(required_items, self.player) and badge_requirement(state)
 
     def can_fly(self) -> CollectionRule:
         badge_requirement = self.has_hm_badge_requirement("FLY", kanto=False)
-        return lambda state: state.has_all(("HM02 Fly", "Teach FLY"), self.player) and badge_requirement(state)
+        required_items = {"HM02 Fly"}
+        if not self.options.field_moves_always_usable:
+            required_items.add("Teach FLY")
+        return lambda state: state.has_all(required_items, self.player) and badge_requirement(state)
 
     def can_surf(self, kanto: bool = False) -> CollectionRule:
         badge_requirement = self.has_hm_badge_requirement("SURF", kanto=kanto)
-        return lambda state: state.has_all(("HM03 Surf", "Teach SURF"), self.player) and badge_requirement(state)
+        required_items = {"HM03 Surf"}
+        if not self.options.field_moves_always_usable:
+            required_items.add("Teach SURF")
+        return lambda state: state.has_all(required_items, self.player) and badge_requirement(state)
 
     def can_strength(self, kanto: bool = False) -> CollectionRule:
         badge_requirement = self.has_hm_badge_requirement("STRENGTH", kanto=kanto)
-        return lambda state: state.has_all(("HM04 Strength", "Teach STRENGTH"), self.player) and badge_requirement(
-            state)
+        required_items = {"HM04 Strength"}
+        if not self.options.field_moves_always_usable:
+            required_items.add("Teach STRENGTH")
+        return lambda state: state.has_all(required_items, self.player) and badge_requirement(state)
 
     def can_flash(self, kanto: bool = False) -> CollectionRule:
         if self.options.require_flash == RequireFlash.option_not_required:
             return lambda _: True
         badge_requirement = self.has_hm_badge_requirement("FLASH", kanto=kanto)
-        return lambda state: state.has_all(("HM05 Flash", "Teach FLASH"), self.player) and badge_requirement(state)
+        required_items = {"HM05 Flash"}
+        if not self.options.field_moves_always_usable:
+            required_items.add("Teach FLASH")
+        return lambda state: state.has_all(required_items, self.player) and badge_requirement(state)
 
     def can_whirlpool(self, kanto: bool = False) -> CollectionRule:
         badge_requirement = self.has_hm_badge_requirement("WHIRLPOOL", kanto=kanto)
-        return lambda state: state.has_all(("HM06 Whirlpool", "Teach WHIRLPOOL"), self.player) and badge_requirement(
-            state)
+        required_items = {"HM06 Whirlpool"}
+        if not self.options.field_moves_always_usable:
+            required_items.add("Teach WHIRLPOOL")
+        return lambda state: state.has_all(required_items, self.player) and badge_requirement(state)
 
     def can_waterfall(self, kanto: bool = False) -> CollectionRule:
         badge_requirement = self.has_hm_badge_requirement("WATERFALL", kanto=kanto)
-        return lambda state: state.has_all(("HM07 Waterfall", "Teach WATERFALL"), self.player) and badge_requirement(
-            state)
+        required_items = {"HM07 Waterfall"}
+        if not self.options.field_moves_always_usable:
+            required_items.add("Teach WATERFALL")
+        return lambda state: state.has_all(required_items, self.player) and badge_requirement(state)
 
     def can_headbutt(self) -> CollectionRule:
-        return lambda state: state.has_all(("TM02", "Teach HEADBUTT"), self.player)
+        required_items = {"TM02"}
+        if not self.options.field_moves_always_usable:
+            required_items.add("Teach HEADBUTT")
+        return lambda state: state.has_all(required_items, self.player
 
     def can_rock_smash(self) -> CollectionRule:
-        return lambda state: state.has_all(("TM08", "Teach ROCK_SMASH"), self.player)
+        required_items = {"TM08"}
+        if not self.options.field_moves_always_usable:
+            required_items.add("Teach ROCK_SMASH")
+        return lambda state: state.has_all(required_items, self.player)
 
     def has_tea(self) -> CollectionRule:
         return lambda state: state.has("Tea", self.player)

--- a/worlds/pokemon_crystal/world.py
+++ b/worlds/pokemon_crystal/world.py
@@ -344,7 +344,8 @@ class PokemonCrystalWorld(World):
 
         if self.is_universal_tracker: return
 
-        verify_hm_accessibility(self)
+        if not self.options.field_moves_always_usable:
+            verify_hm_accessibility(self)
         randomize_move_values(self)
         cap_hm_move_power(self)
         randomize_traded_pokemon(self)
@@ -407,7 +408,8 @@ class PokemonCrystalWorld(World):
                 logging.debug(f"Failed to shuffle badges for player {self.player} ({self.player_name}). Retrying.")
 
             self.logic.guaranteed_hm_access = False
-            verify_hm_accessibility(self)
+            if not self.options.field_moves_always_usable:
+                verify_hm_accessibility(self)
 
     @classmethod
     def stage_generate_output(cls, multiworld: MultiWorld, output_directory: str):


### PR DESCRIPTION
Thanks for contributing to the Pokémon Crystal Archipelago project!

Adds the Field Moves Always Usable option supported by the basepatch and reworks the logic to take it into account
Also tell about the Field Move Menu in the docs

I assumed that the calls to `verify_tm_accessibility` were skippable with this, but tell me if I was wrong, especially in `pre_fill`