### PR TITLE
Docs: Add French game docs + Add some details to English

### DIFF
--- a/worlds/pokemon_crystal/docs/en_Pokemon Crystal.md
+++ b/worlds/pokemon_crystal/docs/en_Pokemon Crystal.md
@@ -26,24 +26,33 @@ Some changes have been made to the base game for this randomizer:
     - HM05 Flash - Boulder Badge
     - HM06 Whirlpool - Volcano Badge
     - HM07 Waterfall - Earth Badge
-- An in-game option for not requiring Field Moves to be taught was added. To keep Fly, Flash, and other Field Moves accessible, an additional menu is made available by pressing Select on the Start Menu.
+- TM02 and TM08 will always be Headbutt and Rock Smash respectively, and are always reusable
+- Trade evolutions have been changed to make them possible in a solo run of the game:
+    - Regular trade evolutions now evolve at level 37
+    - Held item trade evolutions evolve when their evolution item is used on them, as you would an evolution stone
+- Eevee evolves into Espeon and Umbreon with the Sun Stone and Moon Stone respectively
+- Happiness evolutions are logically tied to access to the Goldenrod Underground or Pallet Town. The younger haircut
+  brother and Daisy will max out a Pokémon's happiness and are always available
 - Tin Tower 1F is accessible once you obtain the Clear Bell.
 - Tin Tower 2F+ is accessible once the aforementioned condition is met, and you have the Rainbow Wing. Both are items in
   the multiworld
 - Eusine will give you an Eon Mail if you talk to him in Tin Tower 1F after seeing Suicune in the overworld at all
   possible locations, which you can visit in any order
+- The Celebi Event can be activated by giving the multiworld item GS-Ball to Kurt after clearing Slowpoke Well and
+  defeating the rival in Azalea
+- The event which usually grants the GS Ball in Goldenrod Pokécenter 1F activates after becoming champion
 - The Ruins of Alph Ho-Oh item chamber is accessible by owning the Rainbow Wing
 - A shop has been added to 2F of all Pokémon Centers, you can customise what this shop sells using the `build_a_mart`
   option, the shop will always sell Poké Balls and Escape Ropes
 - An NPC which allows you to fight a random wild Pokémon has been added to 2F of all Pokémon Centers, this fight awards
   money and exp, but does not grant Pokédex entries and is not catchable
-- The event which usually grants the GS Ball in Goldenrod Pokécenter 1F activates after becoming champion
 
 ## What items and locations get randomized?
 
 By default, items from item balls and items given by NPCs are randomized.
-Badges can be either vanilla, shuffled or randomized. Pokégear and its card modules can be vanilla or shuffled.
+Badges can be either vanilla, shuffled or randomized. Pokégear and its card modules can be vanilla or randomized.
 If Johto Only mode is enabled, items in Kanto will not be randomized and Kanto will be inaccessible.
+The S.S. Ticket given by Elm after beating the Elite 4 will also be replaced by the Silver Wing.
 
 There are options to include more items in the pool:
 
@@ -58,21 +67,20 @@ There are options to include more items in the pool:
 
 Many additional quality of life changes have been implemented:
 
-- A new text speed option, Instant, is added to the options menu in game. This speeds up text and allows holding A to
-  quickly speed through dialog
+- A new text speed option, Instant, is added to the options menu in game.
+- The A and/or B buttons can be used as turbo buttons to speed through dialogues
 - When battle scenes are turned off, HP reduction and XP gain animations are skipped
-- You can hold B to run
+- The Battle Scene option is more granular, with the fastest choice, Speedy, cutting nearly every animation
+- You can hold B to run. An Auto-run option also exists, and if enabled, B prevents you from running
+- Many other options were added to drastically speed up gameplay, including: Rods can always work, Uncaught Pokémon can be
+  more likely to appear, Trainers can be blind, etc.
 - Lag in menus has been removed
 - The Bicycle can be used indoors
 - If a repel runs out and you have more in your Pack, you will be prompted to use another
 - Pokémon growth rates are normalized (Medium-Fast for non-Legendary Pokémon, Slow for Legendary Pokémon)
 - The clock reset password system has been removed, you can reset the clock with Down + Select + B on the title screen
-- Trade evolutions have been changed to make them possible in a solo run of the game:
-    - Regular trade evolutions now evolve at level 37
-    - Held item trade evolutions evolve when their evolution item is used on them, as you would an evolution stone
-- Espeon and Umbreon evolve with the Sun Stone and Moon Stone respectively
-- The Celebi Event can be activated by giving the multiworld item GS-Ball to Kurt after clearing Slowpoke Well and
-  defeating the rival in Azalea
+- An in-game option for not requiring Field Moves to be taught was added. To keep Fly, Flash, and other Field Moves
+  accessible, an additional menu is made available by pressing Select on the Start Menu
 - You can respawn all static events by talking to the Time Capsule person in the second floor of any PokéCenter
 - You can teleport back to your starting town by selecting "Go Home" in the main menu before you load into the
   overworld

--- a/worlds/pokemon_crystal/docs/fr_Pokemon Crystal.md
+++ b/worlds/pokemon_crystal/docs/fr_Pokemon Crystal.md
@@ -28,7 +28,7 @@ Quelques changements ont été faits au jeu de base pour ce randomizer :
 	- CS03 Surf - Badge Âme
 	- CS04 Force - Badge Prisme
 	- CS05 Flash - Badge Roche
-	- CS06 Spihon - Badge Volcan
+	- CS06 Siphon - Badge Volcan
 	- CS07 Cascade - Badge Terre
 - La CT02 et la CT08 seront toujours respectivement Coup d'Boule et Éclate-Roc, et sont toujours réutilisables
 - Les évolutions par échange ont été changées pour les rendre possible dans une partie solo :

--- a/worlds/pokemon_crystal/docs/fr_Pokemon Crystal.md
+++ b/worlds/pokemon_crystal/docs/fr_Pokemon Crystal.md
@@ -15,7 +15,7 @@ Quelques changements ont été faits au jeu de base pour ce randomizer :
 - Les checks basés sur le temps, tels que la Fratrie des Sept et l'homme du toit du Manoir Céladon sont toujours
   disponibles
     - Les objets cachés sous Vanessa (Frieda) et Homer (Wesley) ont été bougés d'une case sur le côté pour rester
-	  accessibles
+      accessibles
 - Le Bateau entre Oliville et Carmin sur Mer est toujours présent dans des parties non-Johto-seulement,
   même avant d'accéder au Panthéon, et peut être monté à bord avec le Passe Bateau
 - Le train magnétique entre Doublonville et Safrania peut être monté à bord avec le Passe avant que
@@ -34,7 +34,7 @@ Quelques changements ont été faits au jeu de base pour ce randomizer :
 - Les évolutions par échange ont été changées pour les rendre possible dans une partie solo :
     - Les évolutions par échange normales se font maintenant au niveau 37
     - Les évolutions par échange et objet tenu se font quand leur objet d'évolution est utilisé sur le Pokémon, comme
-	  avec une pierre d'évolution
+      avec une pierre d'évolution
 - Évoli évolue en Mentali et Noctali respectivement avec la Pierre Soleil et la Pierre Lune
 - Les évolutions par bonheur sont logiquement liées à l'accès au Souterrain de Doublonville ou Bourg Palette.
   Le cadet des frères coiffeurs et Nina maximiseront le bonheur d'un Pokémon et sont toujours disponibles

--- a/worlds/pokemon_crystal/docs/fr_Pokemon Crystal.md
+++ b/worlds/pokemon_crystal/docs/fr_Pokemon Crystal.md
@@ -22,7 +22,7 @@ Quelques changements ont été faits au jeu de base pour ce randomizer :
   l'électricité de Kanto ne soit restaurée
 - Ondine est toujours dans l'Arène d'Azuria
 - Un rebord sur la Route 45 a été bougé pour que tous les objets et dresseurs puissent être accédés en 2 passages
-- Pour les options qui le permettent, les badges de Kanto correspondent aux CS suivantes:
+- Pour les options qui le permettent, les badges de Kanto correspondent aux CS suivantes :
 	- CS01 Coupe - Badge Cascade
 	- CS02 Vol - Badge Foudre
 	- CS03 Surf - Badge Âme
@@ -99,7 +99,7 @@ De nombreux changements de qualité de vie ont été implémentés :
 - Tous les événements statiques peuvent réapparaître en parlant à la personne du Bloc Temporel au premier étage
   de n'importe quel Centre Pokémon
 - Il est possible de se téléporter à la ville de départ en séléctionnant "*Go Home*" dans le menu principal
-  avant de charger le monde
+  avant de charger la partie
 
 ## À quoi ressemble un objet d'un autre monde dans Pokémon Cristal ?
 

--- a/worlds/pokemon_crystal/docs/fr_Pokemon Crystal.md
+++ b/worlds/pokemon_crystal/docs/fr_Pokemon Crystal.md
@@ -1,0 +1,118 @@
+# Pokémon Cristal
+
+## Où est la page d'options ?
+
+Vous pouvez voir toutes les options et générer un YAML [ici](../player-options).
+
+## Que fait la randomization dans ce jeu ?
+
+Quelques changements ont été faits au jeu de base pour ce randomizer :
+
+- Le combat de dresseurs sur la Route 30 se termine dès la fin de la visite chez M. Pokémon, évitant de revenir
+  voir le Professeur Orme
+- Le directeur est toujours dans l'entrepôt du souterrain, même quand la Tour Radio n'est pas occuppée
+- La porte dans le sous-sol du Centre Commercial de Doublonville s'ouvre avec la Carte Magnétique dans le Sac
+- Les checks basés sur le temps, tels que la Fratrie des Sept et l'homme du toit du Manoir Céladon sont toujours
+  disponibles
+	- Les objets cachés sous Vanessa (Frieda) et Homer (Wesley) ont été bougés d'une case sur le côté pour rester
+	  accessibles
+- Le Bateau entre Oliville et Carmin sur Mer est toujours présent dans des parties non-Johto-seulement,
+  même avant d'accéder au Panthéon, et peut être monté à bord avec le Passe Bateau
+- Le train magnétique entre Doublonville et Safrania peut être monté à bord avec le Passe avant que
+  l'électricité de Kanto ne soit restaurée
+- Ondine est toujours dans l'Arène d'Azuria
+- Un rebord sur la Route 45 a été bougé pour que tous les objets et dresseurs puissent être accédés en 2 passages
+- Pour les options qui le permettent, les badges de Kanto correspondent aux CS suivantes:
+	- CS01 Coupe - Badge Cascade
+	- CS02 Vol - Badge Foudre
+	- CS03 Surf - Badge Âme
+	- CS04 Force - Badge Prisme
+	- CS05 Flash - Badge Roche
+	- CS06 Spihon - Badge Volcan
+	- CS07 Cascade - Badge Terre
+- La CT02 et la CT08 seront toujours respectivement Coup d'Boule et Éclate-Roc, et sont toujours réutilisables
+- Les évolutions par échange ont été changées pour les rendre possible dans une partie solo :
+    - Les évolutions par échange normales se font maintenant au niveau 37
+	- Les évolutions par échange et objet tenu se font quand leur objet d'évolution est utilisé sur le Pokémon, comme
+	  avec une pierre d'évolution
+- Évoli évolue en Mentali et Noctali respectivement avec la Pierre Soleil et la Pierre Lune
+- Les évolutions par bonheur sont logiquement liées à l'accès au Souterrain de Doublonville ou Bourg Palette.
+  Le cadet des frères coiffeurs et Nina maximiseront le bonheur d'un Pokémon et sont toujours disponibles
+- Le RDC de la Tour Ferraille est accessible une fois que le Glas Transparent est acquis.
+- Les étages supérieurs de la Tour Ferraille sont accessibles une fois que la condition ci-dessus est satisfaite,
+  et que l'Arcenci'Aile est acquise. Les deux objets sont dans le Multiworld.
+- Eusine donnera une Lettre Évoli en lui parlant au RDC de la Tour Ferraille après avoir vu Suicune
+  à tous ses emplacements dans le monde, qui sont visitables dans n'importe quel ordre.
+- Aux Ruines d'Alpha, la chambre à objets de Ho-Oh est accessible en possédant l'Arcenci'Aile
+- L'événement de Celebi peut être activé en donnant la GS Ball à Fargas après avoir terminé le Puits Ramoloss
+  et avoir battu le rival à Écorcia
+- L'événement qui donne habituellement la GS Ball dans le Centre Pokémon de Doublonville s'active après
+  être devenu Maître
+- Une boutique a été ajoutée au premier étage de chaque Centre Pokémon. Il est possible de personnaliser
+  ce que cette boutique vend avec l'option `build_a_mart`, mais elle vendra toujours des Poké Balls
+  et des Cordes Sortie
+- Un PNJ permettant de combattre des Pokémon sauvages aléatoires a été ajouté au premier étage de chaque Centre
+  Pokémon, ce combat donne de l'argent et de l'exp, mais ne donne pas d'entrées du Pokédex, et le Pokémon n'est
+  pas capturable
+
+## Quels objets et emplacements se font randomizer ?
+
+Par défaut, les objets situés par terre et les objets donnés par les PNJ sont randomizés.
+Les badges peuvent être vanilla, mélangés entre eux ou randomizés. Le Pokématos et ses coupons peuvent être
+vanilla ou randomizés.
+Si le mode Johto Seulement est activé, les objets de Kanto ne seront pas randomizés et Kanto sera inaccessible.
+Le Passe Bateau donné par Orme après avoir vaincu le Conseil 4 sera aussi remplacé par l'Aile Argentée.
+
+Il y a des options pour ajouter plus d'objets dans le pool d'objets :
+
+- Randomizer les Objets Cachés : Ajoute les objets cachés au pool
+- Randomizer les Arbres à Baie : Ajoute les objets des arbres à baie au pool
+- Trainersanity : Ajoute une récompense pour avoir vaincu des dresseurs au pool
+- Dexsanity : L'entrée Pokédex d'un Pokémon peut détenir un check, et est liée à des Pokémon spécifiques.
+- Dexcountsanity : Un certain nombre d'entrées Pokédex détiennent des checks.
+  Ce n'est pas lié à des Pokémon spécifiques mais à un total.
+- Shopsanity : Inclut les objets des boutiques dans le pool
+
+## Quels autres changements ont été faits au jeu ?
+
+De nombreux changements de qualité de vie ont été implémentés :
+
+- Une nouvelle vitesse de texte, Instantanée, a été ajoutée au menu d'options du jeu.
+- Les boutons A et/ou B peuvent être utilisés comme boutons turbo dans les dialogues
+- L'option des Animations de Combat est plus granulaire. Le choix le plus rapide, *Speedy*, enlève quasiment toutes
+  les animations
+- B peut être maintenu pour courir. Une option de course automatique existe. Si elle est activée, B empêchera de
+  courir.
+- De nombreuses autres options ont été ajoutées pour drastiquement accélérer le gameplay, y compris : Les cannes
+  à pêches peuvent toujours fonctionner, les Pokémon non-capturés peuvent avoir plus de chances d'apparaître, les
+  dresseurs peuvent être aveugles, etc.
+- Le lag dans les menus a été enlevé
+- La Bicyclette peut être utilisée en intérieur
+- Si un repousse se dissippe et qu'il en reste dans le Sac, le jeu donne le choix d'en utiliser un autre
+- Les taux de croissance des Pokémon sont normalisés (Moyen-Rapide pour les Pokémon non-Légendaires, Lent pour les
+  Pokémon Légendaires)
+- Le système de mot de passe pour l'horloge a été enlevé, et l'horloge peut être réinitialisée en faisant
+  Bas + Select + B sur l'écran titre
+- Une option a été ajoutée au jeu pour ne pas requérir d'apprendre de Capacités à effet hors-combat.
+  Pour garder Vol, Flash, et d'autres capacités accessibles, un menu additionnel est disponible
+  en appuyant sur Select dans le Menu Start.
+- Tous les événements statiques peuvent réapparaître en parlant à la personne du Bloc Temporel au premier étage
+  de n'importe quel Centre Pokémon
+- Il est possible de se téléporter à la ville de départ en séléctionnant "*Go Home*" dans le menu principal
+  avant de charger le monde
+
+## À quoi ressemble un objet d'un autre monde dans Pokémon Cristal ?
+
+Les objets d'autres mondes indiqueront les noms de l'objet et du joueur destinataire une fois collectés. À cause de
+limitations avec le texte du jeu, ces noms sont tronqués à 16 caractères, et les caractères spéciaux non
+présents dans la police du jeu sont replacés par des points d'interrogation.
+
+## Quand le joueur reçoit un objet, que se passe-t-il ?
+
+Un son jouera quand un objet est reçu si l'option *Item Receive Sound* (Son de Réception d'Objet) est activée.
+Des sons différents joueront pour distinguer les objets de progression et les pièges.
+
+## Puis-je jouer hors-ligne ?
+
+Oui, ce jeu n'a pas besoin d'être connecté au client pour des graines solo. Une connexion est uniquement requise
+pour envoyer et recevoir des objets. Ceci ne s'applique pas lorsque l'option `remote_items` est active.

--- a/worlds/pokemon_crystal/docs/fr_Pokemon Crystal.md
+++ b/worlds/pokemon_crystal/docs/fr_Pokemon Crystal.md
@@ -14,7 +14,7 @@ Quelques changements ont été faits au jeu de base pour ce randomizer :
 - La porte dans le sous-sol du Centre Commercial de Doublonville s'ouvre avec la Carte Magnétique dans le Sac
 - Les checks basés sur le temps, tels que la Fratrie des Sept et l'homme du toit du Manoir Céladon sont toujours
   disponibles
-	- Les objets cachés sous Vanessa (Frieda) et Homer (Wesley) ont été bougés d'une case sur le côté pour rester
+    - Les objets cachés sous Vanessa (Frieda) et Homer (Wesley) ont été bougés d'une case sur le côté pour rester
 	  accessibles
 - Le Bateau entre Oliville et Carmin sur Mer est toujours présent dans des parties non-Johto-seulement,
   même avant d'accéder au Panthéon, et peut être monté à bord avec le Passe Bateau
@@ -23,17 +23,17 @@ Quelques changements ont été faits au jeu de base pour ce randomizer :
 - Ondine est toujours dans l'Arène d'Azuria
 - Un rebord sur la Route 45 a été bougé pour que tous les objets et dresseurs puissent être accédés en 2 passages
 - Pour les options qui le permettent, les badges de Kanto correspondent aux CS suivantes :
-	- CS01 Coupe - Badge Cascade
-	- CS02 Vol - Badge Foudre
-	- CS03 Surf - Badge Âme
-	- CS04 Force - Badge Prisme
-	- CS05 Flash - Badge Roche
-	- CS06 Siphon - Badge Volcan
-	- CS07 Cascade - Badge Terre
+    - CS01 Coupe - Badge Cascade
+    - CS02 Vol - Badge Foudre
+    - CS03 Surf - Badge Âme
+    - CS04 Force - Badge Prisme
+    - CS05 Flash - Badge Roche
+    - CS06 Siphon - Badge Volcan
+    - CS07 Cascade - Badge Terre
 - La CT02 et la CT08 seront toujours respectivement Coup d'Boule et Éclate-Roc, et sont toujours réutilisables
 - Les évolutions par échange ont été changées pour les rendre possible dans une partie solo :
     - Les évolutions par échange normales se font maintenant au niveau 37
-	- Les évolutions par échange et objet tenu se font quand leur objet d'évolution est utilisé sur le Pokémon, comme
+    - Les évolutions par échange et objet tenu se font quand leur objet d'évolution est utilisé sur le Pokémon, comme
 	  avec une pierre d'évolution
 - Évoli évolue en Mentali et Noctali respectivement avec la Pierre Soleil et la Pierre Lune
 - Les évolutions par bonheur sont logiquement liées à l'accès au Souterrain de Doublonville ou Bourg Palette.


### PR DESCRIPTION
## What does this add?
- Adds `fr_Pokemon Crystal.md`, using all localized names
  - My only minor nitpick is it doesn't seem like French has a proper way of calling Field Moves and are only ever called "Moves with effects outside battle"
- Rearrange some things in the English docs, and add a few details I felt were worth noting
  - Add bit about Headbutt and Rock Smash not being part of TM Rando
  - Move blurbs about evolutions into the "main changes" section, since they affect logic
    - Also added a point on happiness evolutions
  - Move blurb about Celebi and GS Ball events into the "main changes" section, for the same reason
  - Added a point about S.S. Ticket being replaced with Silver Wing in Johto Only
  - Reworded instant text/battle scene since it seems it hasn't changed since 3.0
  - Moved bit about the Field Move Menu into the "other changes" section

Didn't add a setup guide since it's the same for all bizhawk games anyway
Feel free to ping me when you modify the English docs so I can apply that to French as well

## Why do you want it to be added?
:Frenchge:

## Was this tested yet?
No (couldn't run webhost)