### PR TITLE
Options: Add TM Plando

### DIFF
--- a/worlds/pokemon_crystal/moves.py
+++ b/worlds/pokemon_crystal/moves.py
@@ -139,12 +139,31 @@ def get_tmhm_compatibility(world: "PokemonCrystalWorld", pkmn_name):
     return tmhms
 
 
+def apply_tm_plando(world: "PokemonCrystalWorld") -> dict[int, str]:
+    move_friendly_to_ids = {move_data.name.title(): move_id for move_id, move_data in world.generated_moves.items()}
+    plando_data = {tm_num: move_friendly_to_ids[move] for tm_num, move in world.options.tm_plando.value.items()}
+    if (world.options.dexsanity or world.options.dexcountsanity) and "SWEET_SCENT" not in plando_data.values() and \
+            12 in plando_data:
+                plando_data.pop(12)
+    for tm_name, tm_data in world.generated_tms.items():
+        if tm_data.is_hm or tm_data.tm_num not in plando_data:
+            continue
+        move = world.generated_moves[plando_data[tm_data.tm_num]]
+        world.generated_tms[tm_name] = TMHMData(move.id, tm_data.tm_num, move.type, False, move.rom_id)
+    return plando_data
+
+
 def randomize_tms(world: "PokemonCrystalWorld"):
+    plandoed_tms = dict()
+    if world.options.tm_plando and not world.options.metronome_only:
+        plandoed_tms = apply_tm_plando(world)
     if not world.options.randomize_tm_moves and not world.options.metronome_only: return
 
-    ignored_moves = ["ROCK_SMASH", "NO_MOVE", "STRUGGLE", "HEADBUTT"]
-    if world.options.dexsanity or world.options.dexcountsanity:
-        ignored_moves.append("SWEET_SCENT")
+    plandoed_tms[2] = "HEADBUTT"
+    plandoed_tms[8] = "ROCK_SMASH"
+    if (world.options.dexsanity or world.options.dexcountsanity) and "SWEET_SCENT" not in plandoed_tms.values():
+        plandoed_tms[12] = "SWEET_SCENT"
+    ignored_moves = ["NO_MOVE", "STRUGGLE"] + list(plandoed_tms.values())
     global_move_pool = [move_data for move_name, move_data in world.generated_moves.items() if
                         not move_data.is_hm
                         and move_name not in ignored_moves]
@@ -156,7 +175,7 @@ def randomize_tms(world: "PokemonCrystalWorld"):
     world.random.shuffle(filtered_move_pool)
 
     for tm_name, tm_data in world.generated_tms.items():
-        if tm_data.is_hm or tm_name in ignored_moves:
+        if tm_data.is_hm or tm_data.tm_num in plandoed_tms:
             continue
         if world.options.metronome_only:
             new_move = world.generated_moves["METRONOME"]

--- a/worlds/pokemon_crystal/moves.py
+++ b/worlds/pokemon_crystal/moves.py
@@ -142,9 +142,6 @@ def get_tmhm_compatibility(world: "PokemonCrystalWorld", pkmn_name):
 def apply_tm_plando(world: "PokemonCrystalWorld") -> dict[int, str]:
     move_friendly_to_ids = {move_data.name.title(): move_id for move_id, move_data in world.generated_moves.items()}
     plando_data = {tm_num: move_friendly_to_ids[move] for tm_num, move in world.options.tm_plando.value.items()}
-    if (world.options.dexsanity or world.options.dexcountsanity) and "SWEET_SCENT" not in plando_data.values() and \
-            12 in plando_data:
-                plando_data.pop(12)
     for tm_name, tm_data in world.generated_tms.items():
         if tm_data.is_hm or tm_data.tm_num not in plando_data:
             continue

--- a/worlds/pokemon_crystal/options.py
+++ b/worlds/pokemon_crystal/options.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from Options import Toggle, Choice, DefaultOnToggle, Range, PerGameCommonOptions, NamedRange, OptionSet, \
+from Options import OptionError, Toggle, Choice, DefaultOnToggle, Range, PerGameCommonOptions, NamedRange, OptionSet, \
     StartInventoryPool, OptionDict, Visibility, DeathLink, OptionGroup, OptionList, FreeText
 from .data import data, MapPalette
 from .maps import FLASH_MAP_GROUPS
@@ -1059,6 +1059,36 @@ class RandomizeTMMoves(Toggle):
     display_name = "Randomize TM Moves"
 
 
+class TMPlando(OptionDict):
+    """
+    Specify what move a TM will contain.
+    TMs 02 and 08 can never be plandoed. This also means Headbutt and Rock Smash cannot be plandoed onto other TMs.
+    If Dexsanity or Dexcountsanity are enabled, and Sweet Scent hasn't been plandoed, it will be forced to TM12.
+    This option takes priority over the TM Blocklist and vanilla TMs, and is ignored in Metronome Only mode.
+
+    Uses the following format:
+    tm_plando:
+      1: Dynamicpunch
+      3: Curse
+      10: Hidden Power
+      ...
+    """
+    display_name = "TM Plando"
+    valid_keys = set(range(1, 51)) - {2, 8}
+    valid_values = set(sorted(move.name.title() for id, move in data.moves.items() if id not in ("NO_MOVE", "STRUGGLE",
+        "HEADBUTT", "ROCK_SMASH", "CUT", "FLY", "SURF", "STRENGTH", "FLASH", "WHIRLPOOL", "WATERFALL")))
+
+    def verify_keys(self) -> None:
+        super(OptionDict, self).verify_keys()
+        data = set(self.value.values())
+        extra = data - self.valid_values
+        if extra:
+            raise OptionError(
+                f"Found unexpected value {', '.join(extra)} in {getattr(self, 'display_name', self)}. "
+                f"Allowed values: {self.valid_values}."
+            )
+
+
 class TMCompatibility(NamedRange):
     """
     Percent chance for Pokemon to be compatible with each TM
@@ -1761,6 +1791,7 @@ class PokemonCrystalOptions(PerGameCommonOptions):
     randomize_type_chart: RandomizeTypeChart
     physical_special_split: PhysicalSpecialSplit
     randomize_tm_moves: RandomizeTMMoves
+    tm_plando: TMPlando
     tm_compatibility: TMCompatibility
     hm_compatibility: HMCompatibility
     hm_power_cap: HMPowerCap
@@ -1910,6 +1941,7 @@ OPTION_GROUPS = [
          PhysicalSpecialSplit,
          HMPowerCap,
          RandomizeTMMoves,
+         TMPlando,
          TMCompatibility,
          ReusableTMs,
          MoveBlocklist,

--- a/worlds/pokemon_crystal/rom.py
+++ b/worlds/pokemon_crystal/rom.py
@@ -537,7 +537,7 @@ def generate_output(world: "PokemonCrystalWorld", output_directory: str, patch: 
             write_bytes(patch, pokemon_data, address)
             address += len(pokemon_data)
 
-    if world.options.randomize_tm_moves.value or world.options.metronome_only.value:
+    if world.options.randomize_tm_moves.value or world.options.metronome_only.value or world.options.tm_plando.value:
         tm_moves = [tm_data.move_id for _name, tm_data in world.generated_tms.items()]
         address = data.rom_addresses["AP_Setting_TMMoves"]
         write_bytes(patch, tm_moves, address)

--- a/worlds/pokemon_crystal/utils.py
+++ b/worlds/pokemon_crystal/utils.py
@@ -40,6 +40,7 @@ def __adjust_option_problems(world: "PokemonCrystalWorld"):
     __adjust_options_race_mode(world)
     __adjust_options_pokemon_requests(world)
     __adjust_options_dark_areas(world)
+    __adjust_options_tm_plando(world)
 
 
 def __adjust_options_radio_tower_and_route_44(world: "PokemonCrystalWorld"):
@@ -254,6 +255,15 @@ def __adjust_options_dark_areas(world: "PokemonCrystalWorld"):
             "Pokemon Crystal: Non-vanilla dark areas are not compatible with badges that are not completely random. "
             "Resetting dark areas to vanilla for %s (%s).", world.player, world.player_name)
         world.options.dark_areas.value = world.options.dark_areas.default
+
+
+def __adjust_options_tm_plando(world: "PokemonCrystalWorld"):
+    if 12 in world.options.tm_plando.value and "Sweet Scent" not in world.options.tm_plando.value.values() \
+            and (world.options.dexsanity or world.options.dexcountsanity):
+        logging.warning(
+            "Pokemon Crystal: A Sweet Scent TM must exist if Dexsanity or Dexcountsanity are enabled. "
+            "Resetting TM12 to vanilla for Player %s (%s).", world.player, world.player_name)
+        world.options.tm_plando.value.pop(12)
 
 
 def pokemon_convert_friendly_to_ids(world: "PokemonCrystalWorld", pokemon: Iterable[str]) -> set[str]:


### PR DESCRIPTION
## What does this add?
Adds a TM Plando YAML option
- Overrides vanilla TMs and Blocklist
- Can have multiple TMs be the same move
- If Sweet Scent hasn't been plandoed to anything and dex(count)sanity is on, it gets forced to TM12

## Why do you want it to be added?
Felt like the most sensible thing to add plando for

## Was this tested yet?
Fuzzed and tried a couple generations to see if it worked correctly