### PR TITLE
Fix Nidoran breeding edge case

### DIFF
--- a/worlds/pokemon_crystal/world.py
+++ b/worlds/pokemon_crystal/world.py
@@ -787,13 +787,13 @@ class PokemonCrystalWorld(World):
                             f"Evolve {self.generated_pokemon[pokemon_id].friendly_name}")
 
         def get_dexsanity_breeding_hint_data(dexsanity_hint_data: dict[str, list[str]]):
-            for pokemon, data in self.generated_pokemon.items():
-                if not can_breed(self, pokemon): continue
+            for parent, data in self.generated_pokemon.items():
+                if not can_breed(self, parent): continue
                 child = data.produces_egg
-                if pokemon == child: continue
-                parent_name = self.generated_pokemon[pokemon].friendly_name
-                if child == "NIDORAN_F" and "NIDORAN_M" in self.generated_dexsanity:
+                parent_name = self.generated_pokemon[parent].friendly_name
+                if child == "NIDORAN_F" and parent != "NIDORAN_M" and "NIDORAN_M" in self.generated_dexsanity:
                     dexsanity_hint_data["NIDORAN_M"].append(f"Breed {parent_name}")
+                if parent == child: continue
                 if child in self.generated_dexsanity:
                     dexsanity_hint_data[child].append(f"Breed {parent_name}")
 


### PR DESCRIPTION
If a pokemon breeds into itself its hint data gets skipped because duh
But this doesn't properly take into account how breeding NidoranF works, namely if despite randomization NidoranF breeds into itself, it won't say that NidoranM can be obtained by breeding NidoranF.
This should fix it by just checking if the child is NidoranF before checking if the parent and child are the same