### PR TITLE
Fix spoiler writing for python < 3.12

### DIFF
--- a/worlds/pokemon_crystal/world.py
+++ b/worlds/pokemon_crystal/world.py
@@ -724,7 +724,7 @@ class PokemonCrystalWorld(World):
         if self.options.goal == Goal.option_unown_hunt:
             spoiler_handle.write("Unown locations:\n")
             for sign, unown in self.generated_unown_signs.items():
-                spoiler_handle.write(f"{sign}: {unown.replace("_", " ")}\n")
+                spoiler_handle.write(f"{sign}: {unown.replace('_', ' ')}\n")
             spoiler_handle.write("\n")
 
         if self.options.randomize_starters:


### PR DESCRIPTION
Nested double quotes inside a double-quoted f-string causes a syntax error in Python versions before 3.12