### PR TITLE
Customizable Mischief Pool + Mischief Tiers

### DIFF
--- a/worlds/pokemon_crystal/data.py
+++ b/worlds/pokemon_crystal/data.py
@@ -484,7 +484,36 @@ class MiscData:
     saffron_gym_warps: MiscSaffronWarps
     radio_channel_addresses: Sequence[int]
     mom_items: Sequence[MiscMomItem]
-    selected: Sequence[MiscOption] = field(default_factory=lambda: list(MiscOption))
+    selected: Sequence[MiscOption] = field(default_factory=lambda: list())
+
+    tame: Sequence[MiscOption] = field(default_factory=lambda: \
+        [MiscOption.FuchsiaGym,
+         MiscOption.SaffronGym,
+         MiscOption.RadioTowerQuestions,
+         MiscOption.Amphy,
+         MiscOption.FanClubChairman,
+         MiscOption.EcruteakGym,
+         MiscOption.RedGyarados,
+         MiscOption.RadioChannels,
+         MiscOption.MomItems,
+         MiscOption.IcePath,
+         MiscOption.WhirlDexLocations,
+         MiscOption.Farfetchd,
+         MiscOption.DarkAreas]
+    )
+    wild: Sequence[MiscOption] = field(default_factory=lambda: \
+        [MiscOption.SecretSwitch,
+         MiscOption.OhkoMoves, # Not "that bad" but can happen multiple times over an entire run
+         MiscOption.TooManyDogs,
+         MiscOption.VermilionGym]
+    )
+    dynamic: Sequence[MiscOption] = field(default_factory=lambda: [])
+
+    assert len(set(tame.default_factory() + \
+                   wild.default_factory() + \
+                   dynamic.default_factory())) \
+           == max(list(MiscOption)).value, \
+            "Misc options are not properly categorized. Each must be assigned to one of 'tame', 'wild' or 'dynamic'."
 
 
 @dataclass(frozen=True)

--- a/worlds/pokemon_crystal/options.py
+++ b/worlds/pokemon_crystal/options.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 
 from Options import Toggle, Choice, DefaultOnToggle, Range, PerGameCommonOptions, NamedRange, OptionSet, \
     StartInventoryPool, OptionDict, Visibility, DeathLink, OptionGroup, OptionList, FreeText, OptionError
-from .data import data, MapPalette
+from .data import data, MapPalette, MiscOption
 from .maps import FLASH_MAP_GROUPS
 
 
@@ -1739,11 +1739,49 @@ class TrapLink(Toggle):
     display_name = "Trap Link"
 
 
-class EnableMischief(Toggle):
+class EnableMischief(Choice):
     """
     If I told you what this does, it would ruin the surprises :)
     """
     display_name = "Enable Mischief"
+    default = 0
+    option_off = 0
+    alias_false = option_off # For compatibility
+    alias_no = option_off # For compatibility
+    option_tame = 1
+    option_wild = 2
+    alias_true = option_wild # For compatibility
+    alias_on = option_wild # For compatibility
+    alias_yes = option_wild # For compatibility
+
+
+class CustomMischiefPool(OptionSet):
+    """Only allow specific Mischief options"""
+    display_name = "Custom Mischief Pool"
+    visibility = Visibility.none
+    valid_keys = [misc_option.name for misc_option in list(MiscOption)] + ["_Tame", "_Wild"]
+
+
+class MischiefLowerBound(Range):
+    """
+    Lower bound of selectable mischief, in percentage
+    """
+    display_name = "Mischief Lower Bound"
+    visibility = Visibility.none
+    default = 50
+    range_start = 0
+    range_end = 100
+
+
+class MischiefUpperBound(Range):
+    """
+    Upper bound of selectable mischief, in percentage
+    """
+    display_name = "Mischief Upper Bound"
+    visibility = Visibility.none
+    default = 75
+    range_start = 0
+    range_end = 100
 
 
 class MoveBlocklist(OptionSet):
@@ -2115,6 +2153,9 @@ class PokemonCrystalOptions(PerGameCommonOptions):
     field_move_menu_order: FieldMoveMenuOrder
     trainer_name: TrainerName
     enable_mischief: EnableMischief
+    custom_mischief_pool: CustomMischiefPool
+    mischief_lower_bound: MischiefLowerBound
+    mischief_upper_bound: MischiefUpperBound
     start_inventory_from_pool: StartInventoryPool
     death_link: PokemonCrystalDeathLink
     always_unlock_fly_destinations: AlwaysUnlockFly
@@ -2312,7 +2353,10 @@ OPTION_GROUPS = [
     ),
     OptionGroup(
         ":3",
-        [EnableMischief],
+        [EnableMischief,
+         CustomMischiefPool,
+         MischiefLowerBound,
+         MischiefUpperBound],
         False
     )
 ]

--- a/worlds/pokemon_crystal/utils.py
+++ b/worlds/pokemon_crystal/utils.py
@@ -45,6 +45,7 @@ def __adjust_option_problems(world: "PokemonCrystalWorld"):
     __adjust_options_randomize_types(world)
     __adjust_options_tm_plando(world)
     __adjust_options_traps(world)
+    __adjust_options_mischief_bounds(world)
 
 
 def __adjust_options_radio_tower_and_route_44(world: "PokemonCrystalWorld"):
@@ -315,6 +316,15 @@ def __adjust_options_traps(world: "PokemonCrystalWorld"):
             world.player_name
         )
         world.options.filler_trap_percentage.value = maximum_trap_weight
+
+def __adjust_options_mischief_bounds(world: "PokemonCrystalWorld"):
+    if world.options.enable_mischief and \
+       world.options.mischief_lower_bound.value > world.options.mischief_upper_bound.value:
+        world.options.mischief_upper_bound.value = world.options.mischief_lower_bound.value
+        logging.warning("Pokemon Crystal: Adjusted mischief bounds for player %s (%s) :3",
+            world.player,
+            world.player_name
+        )
 
 
 def should_include_region(region: RegionData, world: "PokemonCrystalWorld"):


### PR DESCRIPTION
Thanks for contributing to the Pokémon Crystal Archipelago project!

## What does this add?
- Adds options for customizing which mischief options are eligible and an upper and lower bound. They are invisible
- Splits mischief options into 2 tiers, "Tame" and "Wild" which I hope are self-explanatory
  - The `EnableMischief` option was modified to reflect that change, since it's now a `Choice` I made aliases that would correspond to `Toggle` for compatibility's sake
  - I also added support for dynamic mischief tiers, as I intend in the future to make `WhirlDexLocations` tame or wild depending on whether ER is enabled or not
  - I made `IcePath` tame, ngl I never got this one so idk how bad it is lmao
- Add selected mischief to spoiler log

## Why do you want it to be added?
I hate the Rocket HQ mischief and want to disable it forever (also people talked about that feature from time to time)

## Was this tested yet?
Fuzzed and briefly ran generations to see if the selected spoiler matched with settings