### PR TITLE
Misty "Object event" phone trap

### DIFF
--- a/worlds/pokemon_crystal/data/phone_data.yaml
+++ b/worlds/pokemon_crystal/data/phone_data.yaml
@@ -1406,3 +1406,9 @@ hm02_cut:
     - |
       <player> received
       HM02 CUT!
+
+object_event:
+  caller: withheld
+  script:
+    - |
+      Object event


### PR DESCRIPTION
Thanks for contributing to the Pokémon Crystal Archipelago project!

## What does this add?
Simple phone trap that refers to what Misty said when approached on Route 25 in the old AP implementation of Crystal

## Why do you want it to be added?
cool reference

## Was this tested yet?
surely i'll not fail the fuzzer this time chrisGrin