### PR TITLE
Add string terminator argument to `convert_to_ingame_text`

### DIFF
--- a/worlds/pokemon_crystal_prerelease/rom.py
+++ b/worlds/pokemon_crystal_prerelease/rom.py
@@ -121,7 +121,7 @@ def write_customizable_options(options: PokemonCrystalOptions,
                     data.rom_addresses["AP_Setting_Field_Move_Order"])
 
     if must_write_option("trainer_name"):
-        name_bytes = convert_to_ingame_text(options.trainer_name.value[:7])
+        name_bytes = convert_to_ingame_text(options.trainer_name.value[:7], string_terminator = True)
         write_bytes(name_bytes, data.rom_addresses["AP_Setting_DefaultTrainerName"])
 
     if must_write_option("default_pokedex_mode"):
@@ -752,7 +752,8 @@ def generate_output(world: "PokemonCrystalWorld", output_directory: str, patch: 
         address = data.rom_addresses["AP_Setting_GoldenrodMoveTutorMoveNames"]
         for tm in ("FLAMETHROWER", "THUNDERBOLT", "ICE_BEAM"):
             move_data = world.generated_moves[world.generated_tms[tm].id]
-            move_name = convert_to_ingame_text(move_data.name + " " * (12 - len(move_data.name))) + [0x50]
+            move_name = convert_to_ingame_text(move_data.name + " " * (12 - len(move_data.name)),
+                    string_terminator = True)
             write_bytes(move_name, address)
             address += 13
 

--- a/worlds/pokemon_crystal_prerelease/utils.py
+++ b/worlds/pokemon_crystal_prerelease/utils.py
@@ -513,7 +513,7 @@ def get_mart_slot_location_name(mart: str, index: int):
         return f"Shop Item {index + 1}"
 
 
-def convert_to_ingame_text(text: str) -> list[int]:
+def convert_to_ingame_text(text: str, string_terminator: bool = False) -> list[int]:
     charmap = {
         "…": 0x75, " ": 0x7f, "A": 0x80, "B": 0x81, "C": 0x82, "D": 0x83, "E": 0x84, "F": 0x85, "G": 0x86, "H": 0x87,
         "I": 0x88, "J": 0x89, "K": 0x8a, "L": 0x8b, "M": 0x8c, "N": 0x8d, "O": 0x8e, "P": 0x8f, "Q": 0x90, "R": 0x91,
@@ -526,7 +526,10 @@ def convert_to_ingame_text(text: str) -> list[int]:
         ",": 0xf4, "0": 0xf6, "1": 0xf7, "2": 0xf8, "3": 0xf9, "4": 0xfa, "5": 0xfb, "6": 0xfc, "7": 0xfd, "8": 0xfe,
         "9": 0xff, "_": 0xe3, "♀": 0xf5
     }
-    return [charmap.get(char, charmap["?"]) for char in text]
+    ingame_string = [charmap.get(char, charmap["?"]) for char in text]
+    if string_terminator:
+        ingame_string.append(0x50)
+    return ingame_string
 
 
 def bound(value: int, lower_bound: int, upper_bound: int) -> int:


### PR DESCRIPTION
Thanks for contributing to the Pokémon Crystal Archipelago project!

## What does this add?
Title, also uses that to fix trainer name overrides shorter than what's in the player YAML

## Why do you want it to be added?


## Was this tested yet?
By patching and overriding and checking out Oak's speech was correct