### PR TITLE
Adds alias for Pokedex entries

### DIFF
--- a/worlds/pokemon_crystal_prerelease/locations.py
+++ b/worlds/pokemon_crystal_prerelease/locations.py
@@ -434,3 +434,8 @@ for location in data.locations.values():
         if tag not in LOCATION_GROUPS:
             LOCATION_GROUPS[tag] = set()
         LOCATION_GROUPS[tag].add(location.label)
+
+for pokemon in data.pokemon.values():
+    location = f"Pokedex - {pokemon.friendly_name}"
+    if location in DEXSANITY_LOCATIONS:
+        LOCATION_GROUPS[pokemon.friendly_name] = {location}


### PR DESCRIPTION
Thanks for contributing to the Pokémon Crystal Archipelago project!

## What does this add?

Adds an alias for each Pokemon's Pokedex Entry by way of location groups

## Why do you want it to be added?

It was requested by palex... and i figured it would be simple enough. 

## Was this tested yet?

passed the fuzzer on the second commit, downloaded and tested locally.

[Discord message with snips](https://discord.com/channels/731205301247803413/1365127145709502575/1457223735701672069)