### PR TITLE
Option to make random base stats multiples of 5

### DIFF
--- a/worlds/pokemon_crystal_prerelease/options.py
+++ b/worlds/pokemon_crystal_prerelease/options.py
@@ -1475,7 +1475,7 @@ class RandomizeBaseStats(Choice):
 class BaseStatsMultiplesOfFive(Toggle):
     """
     When randomizing base stats, aim to make the new base stats multiples of 5.
-    If the Pokémon's BST is not a multiple of 5, the remainder will be added to one stat.
+    When using Keep BST, any remainder will be added to one stat.
     """
     display_name = "Make Random Base Stats Multiples of 5"
 

--- a/worlds/pokemon_crystal_prerelease/options.py
+++ b/worlds/pokemon_crystal_prerelease/options.py
@@ -1472,6 +1472,12 @@ class RandomizeBaseStats(Choice):
     option_keep_bst = 1
     option_completely_random = 2
 
+class BaseStatsMultiplesOfFive(Toggle):
+    """
+    When randomizing base stats, aim to make the new base stats multiples of 5.
+    If the Pokémon's BST is not a multiple of 5, the remainder will be added to one stat.
+    """
+    display_name = "Make Random Base Stats Multiples of 5"
 
 class RandomizeTypes(Choice):
     """
@@ -2340,6 +2346,7 @@ class PokemonCrystalOptions(PerGameCommonOptions):
     hm_power_cap: HMPowerCap
     field_moves_always_usable: FieldMovesAlwaysUsable
     randomize_base_stats: RandomizeBaseStats
+    base_stats_multiples_of_five: BaseStatsMultiplesOfFive
     randomize_types: RandomizeTypes
     shared_primary_type: SharedPrimaryType
     randomize_evolution: RandomizeEvolution
@@ -2492,6 +2499,7 @@ OPTION_GROUPS = [
          RandomizeStaticPokemon,
          StaticBlocklist,
          RandomizeBaseStats,
+         BaseStatsMultiplesOfFive,
          RandomizeTypes,
          SharedPrimaryType,
          RandomizeEvolution,

--- a/worlds/pokemon_crystal_prerelease/pokemon.py
+++ b/worlds/pokemon_crystal_prerelease/pokemon.py
@@ -8,7 +8,7 @@ from .evolution import get_random_pokemon_evolution
 from .items import get_random_filler_item
 from .moves import get_tmhm_compatibility, randomize_learnset, moves_convert_friendly_to_ids
 from .options import RandomizeTypes, RandomizePalettes, RandomizeBaseStats, RandomizeStarters, RandomizeTrades, \
-    DexsanityStarters, EncounterGrouping, RandomizePokemonRequests, Goal
+    DexsanityStarters, EncounterGrouping, RandomizePokemonRequests, Goal, BaseStatsMultiplesOfFive
 from .pokemon_data import ALL_UNOWN, LEGENDARY_POKEMON, NON_LEGENDARY_POKEMON
 from .utils import should_include_region
 
@@ -54,10 +54,12 @@ def randomize_pokemon_data(world: "PokemonCrystalWorld"):
                 world.generated_palettes[pkmn_name] = get_random_colors(world.random)
 
         if world.options.randomize_base_stats.value:
+            multiple = 5 if world.options.base_stats_multiples_of_five else 1
+
             if world.options.randomize_base_stats.value == RandomizeBaseStats.option_keep_bst:
-                new_base_stats = get_random_base_stats(world.random, pkmn_data.bst)
+                new_base_stats = get_random_base_stats(world.random, pkmn_data.bst, multiple)
             else:
-                new_base_stats = get_random_base_stats(world.random)
+                new_base_stats = get_random_base_stats(world.random, multiple)
 
         if world.options.randomize_learnsets or world.options.metronome_only:
             new_learnset = randomize_learnset(world, pkmn_name, move_blocklist)
@@ -465,16 +467,28 @@ def get_pokemon_id_by_rom_id(id: int) -> str:
     return next(poke_id for poke_id, poke_data in crystal_data.pokemon.items() if poke_data.id == id)
 
 
-def get_random_base_stats(random, bst=None):
+def get_random_base_stats(random, multiple=1, bst=None):
     if bst is None:
         # sunkern to mewtwo
         bst = random.randint(180, 680)
     # add 0.5 to prevent a single stat exceeding 255
     # biggest possible variance on max bst is (1.5 * 680) / 4 = 255
+    # for this reason, multiple must not be a number where half-to-even rounds ((1.5 * 680) / (4 * multiple)) upward
     randoms = [random.random() + 0.5 for _i in range(0, 6)]
     total = sum(randoms)
-    return [int((stat * bst) / total) for stat in randoms]
+    base_stats = [int(round((stat * bst) / (total * multiple)) * multiple) for stat in randoms]
+    return __place_base_stats_remainder(random, base_stats, bst - sum(base_stats), random.randint(0, 5))
 
+def __place_base_stats_remainder(random, stats: list[int], remainder: int, stat: int):
+    if remainder == 0:
+        return stats
+
+    new_base_stat = stats[stat] + remainder
+    if new_base_stat > 255 or new_base_stat < 5:
+        stats = __place_base_stats_remainder(random, stats, remainder, (stat + 1) % 6)
+    else:
+        stats[stat] = new_base_stat
+    return stats
 
 def get_random_types(world: "PokemonCrystalWorld") -> list[str]:
     all_types = list(crystal_data.types.keys())

--- a/worlds/pokemon_crystal_prerelease/pokemon.py
+++ b/worlds/pokemon_crystal_prerelease/pokemon.py
@@ -57,7 +57,7 @@ def randomize_pokemon_data(world: "PokemonCrystalWorld"):
             multiple = 5 if world.options.base_stats_multiples_of_five else 1
 
             if world.options.randomize_base_stats.value == RandomizeBaseStats.option_keep_bst:
-                new_base_stats = get_random_base_stats(world.random, pkmn_data.bst, multiple)
+                new_base_stats = get_random_base_stats(world.random, multiple, pkmn_data.bst)
             else:
                 new_base_stats = get_random_base_stats(world.random, multiple)
 

--- a/worlds/pokemon_crystal_prerelease/pokemon.py
+++ b/worlds/pokemon_crystal_prerelease/pokemon.py
@@ -470,7 +470,7 @@ def get_pokemon_id_by_rom_id(id: int) -> str:
 def get_random_base_stats(random, multiple=1, bst=None):
     if bst is None:
         # sunkern to mewtwo
-        bst = random.randint(180, 680)
+        bst = random.randrange(180, 681, multiple)
     # add 0.5 to prevent a single stat exceeding 255
     # biggest possible variance on max bst is (1.5 * 680) / 4 = 255
     # for this reason, multiple must not be a number where half-to-even rounds ((1.5 * 680) / (4 * multiple)) upward

--- a/worlds/pokemon_crystal_prerelease/pokemon.py
+++ b/worlds/pokemon_crystal_prerelease/pokemon.py
@@ -8,7 +8,7 @@ from .evolution import get_random_pokemon_evolution
 from .items import get_random_filler_item
 from .moves import get_tmhm_compatibility, randomize_learnset, moves_convert_friendly_to_ids
 from .options import RandomizeTypes, RandomizePalettes, RandomizeBaseStats, RandomizeStarters, RandomizeTrades, \
-    DexsanityStarters, EncounterGrouping, RandomizePokemonRequests, Goal, BaseStatsMultiplesOfFive
+    DexsanityStarters, EncounterGrouping, RandomizePokemonRequests, Goal
 from .pokemon_data import ALL_UNOWN, LEGENDARY_POKEMON, NON_LEGENDARY_POKEMON
 from .utils import should_include_region
 


### PR DESCRIPTION
## What does this add?
An option to have randomized base stats become multiples of 5. 

Some design decisions:
- For fully random, the BST is also made multiples of 5. 
- There can be positive or negative remainders, left by rounding and/or BSTs that are not multiples of 5. These remainders are placed on a single stat that has room for it.

## Why do you want it to be added?
I feel like randomized base stats will be a bit easier to evaluate at a glance with this option on.

## Was this tested yet?
I have generated a few dozen seeds with the random base stats option 50/50 between keep bst and fully random, and have confirmed the stats in game on one of each.