### PR TITLE
Fix get_random_filler_item weighting scheme

### DIFF
--- a/worlds/pokemon_crystal_prerelease/items.py
+++ b/worlds/pokemon_crystal_prerelease/items.py
@@ -72,9 +72,9 @@ EVOLUTION_ITEMS = ("WATER_STONE", "FIRE_STONE", "THUNDERSTONE", "LEAF_STONE", "S
 
 def get_random_filler_item(world: "PokemonCrystalWorld") -> str:
     option = world.options.item_pool_fill
-    if not hasattr(option, "weighted_pool"):
+    if not hasattr(option, "groups"):
         if option == ItemPoolFill.option_balanced:
-            option.weighted_pool = [["RARE_CANDY", "ETHER", "ELIXER", "MAX_ETHER", "MAX_ELIXER", "MYSTERYBERRY",
+            option.groups = [["RARE_CANDY", "ETHER", "ELIXER", "MAX_ETHER", "MAX_ELIXER", "MYSTERYBERRY",
                                      "ESCAPE_ROPE", "NUGGET", "STAR_PIECE", "STARDUST", "PEARL",
                                      "BIG_PEARL", "POKE_BALL", "GREAT_BALL", "ULTRA_BALL", "POTION", "SUPER_POTION",
                                      "ENERGY_ROOT", "ENERGYPOWDER", "HYPER_POTION", "FULL_RESTORE", "REPEL",
@@ -82,50 +82,56 @@ def get_random_filler_item(world: "PokemonCrystalWorld") -> str:
                                      "PP_UP", "PROTEIN", "CARBOS", "CALCIUM", "IRON", "GUARD_SPEC", "DIRE_HIT",
                                      "X_ATTACK", "X_DEFEND", "X_SPEED", "X_SPECIAL", "HEAL_POWDER", "BURN_HEAL",
                                      "PARLYZ_HEAL", "ICE_HEAL", "ANTIDOTE", "AWAKENING", "FULL_HEAL"]]
+            option.weights = [1]
         elif option == ItemPoolFill.option_youngster:
-            option.weighted_pool = [["RARE_CANDY", "ESCAPE_ROPE"] * 11,
-                                    ["ETHER", "ELIXER", "MAX_ETHER", "MAX_ELIXER", "MYSTERYBERRY"] * 9,
-                                    ["GREAT_BALL"] * 1, ["POTION", "POKE_BALL", "REPEL"] * 12,
-                                    ["SUPER_POTION", "ENERGY_ROOT", "ENERGYPOWDER", "SUPER_REPEL"] * 2,
-                                    ["HYPER_POTION", "FULL_RESTORE"] * 1, ["MAX_REPEL"] * 1,
-                                    ["REVIVE", "REVIVAL_HERB"] * 5 + ["MAX_REVIVE"] * 1,
-                                    ["HP_UP", "PP_UP", "PROTEIN", "CARBOS", "CALCIUM", "IRON"] * 1,
+            option.groups = [["RARE_CANDY", "ESCAPE_ROPE"],
+                                    ["ETHER", "ELIXER", "MAX_ETHER", "MAX_ELIXER", "MYSTERYBERRY"],
+                                    ["GREAT_BALL"], ["POTION", "POKE_BALL", "REPEL"],
+                                    ["SUPER_POTION", "ENERGY_ROOT", "ENERGYPOWDER", "SUPER_REPEL"],
+                                    ["HYPER_POTION", "FULL_RESTORE"], ["MAX_REPEL"],
+                                    ["REVIVE", "REVIVAL_HERB"], ["MAX_REVIVE"],
+                                    ["HP_UP", "PP_UP", "PROTEIN", "CARBOS", "CALCIUM", "IRON"],
                                     ["HEAL_POWDER", "BURN_HEAL", "PARLYZ_HEAL", "ICE_HEAL", "ANTIDOTE", "AWAKENING",
-                                     "FULL_HEAL"] * 2]
+                                     "FULL_HEAL"]]
+            option.weights = [11, 9, 1, 12, 2, 1, 1, 5, 1, 1, 2]
         elif option == ItemPoolFill.option_cooltrainer:
-            option.weighted_pool = [["RARE_CANDY", "ESCAPE_ROPE"] * 11,
-                                    ["MAX_ETHER", "MAX_ELIXER", "MYSTERYBERRY"] * 9,
-                                    ["SUPER_POTION", "ENERGY_ROOT", "ENERGYPOWDER", "SUPER_REPEL", "FULL_HEAL"] * 1,
-                                    ["NUGGET", "STAR_PIECE", "STARDUST", "PEARL", "BIG_PEARL"] * 5,
-                                    ["GUARD_SPEC", "DIRE_HIT", "X_ATTACK", "X_DEFEND", "X_SPEED", "X_SPECIAL"] * 10,
-                                    ["HYPER_POTION", "FULL_RESTORE", "MAX_REPEL"] * 10,
-                                    ["REVIVE", "REVIVAL_HERB"] * 5 + ["MAX_REVIVE"] * 10,
-                                    ["HP_UP", "PP_UP", "PROTEIN", "CARBOS", "CALCIUM", "IRON"] * 10,
+            option.groups = [["RARE_CANDY", "ESCAPE_ROPE"],
+                                    ["MAX_ETHER", "MAX_ELIXER", "MYSTERYBERRY"],
+                                    ["SUPER_POTION", "ENERGY_ROOT", "ENERGYPOWDER", "SUPER_REPEL", "FULL_HEAL"],
+                                    ["NUGGET", "STAR_PIECE", "STARDUST", "PEARL", "BIG_PEARL"],
+                                    ["GUARD_SPEC", "DIRE_HIT", "X_ATTACK", "X_DEFEND", "X_SPEED", "X_SPECIAL"],
+                                    ["HYPER_POTION", "FULL_RESTORE", "MAX_REPEL"],
+                                    ["REVIVE", "REVIVAL_HERB"], ["MAX_REVIVE"],
+                                    ["HP_UP", "PP_UP", "PROTEIN", "CARBOS", "CALCIUM", "IRON"],
                                     ["TWISTEDSPOON", "MYSTIC_WATER", "LEFTOVERS", "CHARCOAL", "BRIGHTPOWDER", "MAGNET",
-                                     "SCOPE_LENS", "DRAGON_FANG", "NEVERMELTICE", "SMOKE_BALL"] * 2]
+                                     "SCOPE_LENS", "DRAGON_FANG", "NEVERMELTICE", "SMOKE_BALL"]]
+            option.weights = [11, 9, 1, 5, 10, 10, 5, 10, 10, 2]
         elif option == ItemPoolFill.option_vanilla:
             # weights are roughly based on vanilla occurrence
-            option.weighted_pool = [["RARE_CANDY"] * 3,
-                                    ["ETHER", "ELIXER", "MAX_ETHER", "MAX_ELIXER", "MYSTERYBERRY"] * 5,
-                                    ["ESCAPE_ROPE"] * 3,
-                                    ["NUGGET", "STAR_PIECE", "STARDUST", "PEARL", "BIG_PEARL"] * 2,
-                                    ["POKE_BALL", "GREAT_BALL", "ULTRA_BALL"] * 5,
-                                    ["POTION", "SUPER_POTION", "ENERGY_ROOT", "ENERGYPOWDER"] * 12,
-                                    ["HYPER_POTION", "FULL_RESTORE"] * 2, ["REPEL", "SUPER_REPEL", "MAX_REPEL"] * 3,
-                                    ["REVIVE", "REVIVAL_HERB"] * 4 + ["MAX_REVIVE"] * 2,
-                                    ["HP_UP", "PP_UP", "PROTEIN", "CARBOS", "CALCIUM", "IRON"] * 5,
-                                    ["GUARD_SPEC", "DIRE_HIT", "X_ATTACK", "X_DEFEND", "X_SPEED", "X_SPECIAL"] * 2,
+            option.groups = [["RARE_CANDY"],
+                                    ["ETHER", "ELIXER", "MAX_ETHER", "MAX_ELIXER", "MYSTERYBERRY"],
+                                    ["ESCAPE_ROPE"],
+                                    ["NUGGET", "STAR_PIECE", "STARDUST", "PEARL", "BIG_PEARL"],
+                                    ["POKE_BALL", "GREAT_BALL", "ULTRA_BALL"],
+                                    ["POTION", "SUPER_POTION", "ENERGY_ROOT", "ENERGYPOWDER"],
+                                    ["HYPER_POTION", "FULL_RESTORE"], ["REPEL", "SUPER_REPEL", "MAX_REPEL"],
+                                    ["REVIVE", "REVIVAL_HERB"], ["MAX_REVIVE"],
+                                    ["HP_UP", "PP_UP", "PROTEIN", "CARBOS", "CALCIUM", "IRON"],
+                                    ["GUARD_SPEC", "DIRE_HIT", "X_ATTACK", "X_DEFEND", "X_SPEED", "X_SPECIAL"],
                                     ["HEAL_POWDER", "BURN_HEAL", "PARLYZ_HEAL", "ICE_HEAL", "ANTIDOTE", "AWAKENING",
-                                     "FULL_HEAL"] * 5]
+                                     "FULL_HEAL"]]
+            option.weights = [3, 5, 3, 2, 5, 12, 2, 3, 4, 2, 5, 2, 5]
         elif option == ItemPoolFill.option_shuckle:
-            option.weighted_pool = [
-                ["ESCAPE_ROPE"] * 3, ["NUGGET", "STAR_PIECE", "STARDUST", "PEARL", "BIG_PEARL"] * 2,
-                ["PSNCUREBERRY", "PRZCUREBERRY", "BURNT_BERRY", "ICE_BERRY", "BITTER_BERRY", "MINT_BERRY"] * 5,
-                ["MIRACLEBERRY", "BERRY_JUICE", "MYSTERYBERRY", "BERRY"] * 5, ["POKE_BALL"] * 2]
+            option.groups = [
+                ["ESCAPE_ROPE"], ["NUGGET", "STAR_PIECE", "STARDUST", "PEARL", "BIG_PEARL"],
+                ["PSNCUREBERRY", "PRZCUREBERRY", "BURNT_BERRY", "ICE_BERRY", "BITTER_BERRY", "MINT_BERRY"],
+                ["MIRACLEBERRY", "BERRY_JUICE", "MYSTERYBERRY", "BERRY"], ["POKE_BALL"]]
+            option.weights = [3, 2, 5, 5, 2]
         else:
             # oops :)
-            option.weighted_pool = [["NUGGET"] * 100]
-    group = world.random.choice(option.weighted_pool)
+            option.groups = [["NUGGET"]]
+            option.weights = [1]
+    group = world.random.choices(option.groups, weights=option.weights)[0]
     return world.random.choice(group)
 
 


### PR DESCRIPTION
Thanks for contributing to the Pokémon Crystal Archipelago project!

## What does this add?
Fixes the broken item weighting in `items.get_random_filler_item`

## Why do you want it to be added?
It should be fixed.

## Was this tested yet?
Ran the fuzzer a bit.