### PR TITLE
Polishing up Fly Destination Rando

### DIFF
--- a/worlds/pokemon_crystal_prerelease/client.py
+++ b/worlds/pokemon_crystal_prerelease/client.py
@@ -18,7 +18,7 @@ from .client_event_sync import (SYNC_EVENTS_FLAG_MAP, SYNC_EVENTS_FLAG_MAP_WITH_
                                 SYNC_GOAL_FLAGS, detect_sync_events, encode_sync_bitfield, apply_remote_sync_events,
                                 detect_sync_goal_events, encode_sync_goal_bitfield)
 from .data import data, load_json_data, is_flag_backed_warp
-from .item_data import GRASS_OFFSET, POKEDEX_OFFSET, POKEDEX_COUNT_OFFSET, FLAG_ITEM_OFFSET
+from .item_data import GRASS_OFFSET, POKEDEX_OFFSET, POKEDEX_COUNT_OFFSET, FLAG_ITEM_OFFSET, CANONICAL_ITEM_ID_MASK
 from .items import item_const_name_to_id
 from .options import ProvideShopHints, JohtoOnly
 from .phone import PHONE_TRAP_COUNT
@@ -328,7 +328,7 @@ class PokemonCrystalClient(WonderTradeMixin, BizHawkClient):
             max_consume_polls = 8
             for _ in range(max_items_per_pass):
                 if num_received_items < len(ctx.items_received) and received_item_is_empty:
-                    next_item = ctx.items_received[num_received_items].item
+                    next_item = ctx.items_received[num_received_items].item & CANONICAL_ITEM_ID_MASK
                     original_item = next_item
 
                     writes = []

--- a/worlds/pokemon_crystal_prerelease/data.py
+++ b/worlds/pokemon_crystal_prerelease/data.py
@@ -10,7 +10,7 @@ import orjson
 import yaml
 
 from BaseClasses import ItemClassification
-from .item_data import GRASS_OFFSET, FLAG_ITEM_OFFSET
+from .item_data import GRASS_OFFSET, FLAG_ITEM_OFFSET, CANONICAL_ITEM_ID_MASK
 from .mart_data import FRIENDLY_MART_NAMES, MART_CATEGORIES
 
 
@@ -1287,6 +1287,18 @@ def _init() -> None:
             flag_index=flag_index,
             pocket=pocket,
         )
+
+        if "Fly Unlocks" in attributes["tags"]:
+            items[item_id | (CANONICAL_ITEM_ID_MASK + 1)] = ItemData(
+                label=f"Fly Unlock {flag_index}",
+                item_id=item_id,
+                item_const=f"FLY_UNLOCK_{flag_index}",
+                price=attributes["price"],
+                classification=item_classification,
+                tags=frozenset(attributes["tags"]),
+                flag_index=flag_index,
+                pocket=pocket,
+            )
 
     regions = dict[str, RegionData]()
     locations = dict[str, LocationData]()

--- a/worlds/pokemon_crystal_prerelease/data.py
+++ b/worlds/pokemon_crystal_prerelease/data.py
@@ -1109,6 +1109,32 @@ def internal_entrance_name(name: str) -> str:
     return _CONNECTIONS_BY_FRIENDLY_NAME.get(name.lower(), name)
 
 
+# Friendly names for outdoor maps that have entrance warps, to be used by Fly Destination Plando/Blocklist
+OUTDOOR_WARP_MAP_FRIENDLY_NAMES: list[str] = [
+    "New Bark Town", "Route 29",
+    "Cherrygrove City", "Route 30", "Route 31",
+    "Violet City", "Route 32", "Route 36", "Ruins of Alph Outside",
+    "Azalea Town", "Route 33",
+    "Goldenrod City", "Route 34", "Route 35", # "National Park",
+    "Ecruteak City", "Route 38", "Route 39", "Route 42", "Tin Tower Roof",
+    "Olivine City", "Olivine Port", "Route 40", "Battle Tower Outside",
+    "Cianwood City", "Route 41",
+    "Mahogany Town", "Route 43", "Route 44", "Lake of Rage",
+    "Blackthorn City", "Route 45", "Route 46",
+    "Route 23", "Route 23 Restored", "Route 26", "Route 27",
+    "Silver Cave Outside", "Route 28",
+    "Pallet Town", "Viridian City", "Route 2", "Route 22",
+    "Pewter City", "Route 3", "Mount Moon Square",
+    "Cerulean City", "Route 4", "Route 5", "Route 9", "Route 10 North", "Route 25",
+    "Vermilion City", "Vermilion Port", "Route 6",
+    "Lavender Town", "Route 8", "Route 10 South", "Route 12",
+    "Celadon City", "Route 7", "Route 16",
+    "Saffron City",
+    "Fuchsia City", "Route 15", "Route 17", "Route 18", "Route 19",
+    "Cinnabar Island", "Route 20"
+]
+
+
 data: PokemonCrystalData
 
 

--- a/worlds/pokemon_crystal_prerelease/docs/fly_plando.md
+++ b/worlds/pokemon_crystal_prerelease/docs/fly_plando.md
@@ -1,0 +1,511 @@
+# Fly Destination Plando In Pokemon Crystal
+
+This guide details how to use the Fly Destination Plando and Blocklist options in Pokemon Crystal, how to format them
+and the values that can be used.
+
+## Options formatting
+
+Fly Destination Plando is an structured as a dictionary, where the keys are
+"Fly Destination 1" to "Fly Destination 23", and the accepted values are either a map name or a warp name (listed below),
+or a list of weights for randomly picking values.
+
+Fly Destination Blocklist is structured as a list, which accepts the same values as Fly Destination Plando.
+
+Map names act as shortcuts for every flypoint located on that map.
+
+### Example
+
+```yaml
+  fly_destination_plando:
+    Fly Destination 1: Route 34 Daycare South Entrance
+    Fly Destination 5: Route 41
+    Fly Destination 8:
+      Radio Tower Entrance: 50
+      Lavender Radio Tower Entrance: 50
+
+  fly_destination_blocklist:
+    - Blackthorn City
+    - Route 45
+    - Dark Cave Southeast Entrance
+    - Whirl Islands Northeast Entrance
+```
+
+With this setup, the Fly Unlock 1 item is guaranteed to grant a flypoint to the Route 34 Daycare's yard once obtained.
+The Fly Unlock 5 item will have 3 possible flypoints: the Northwest, Southwest, Southeast entrances to Whirl Islands,
+which are the 3 flypoints remaining on Route 41 after excluding the Northeast entrance, which is part of the blocklist.
+Finally, the Fly Unlock 8 item will grant a flypoint in front of either Goldenrod or Lavender Radio Tower,
+with a 50/50 chance.
+
+Furthermore, the blocklist will ensure that no flypoint ever goes to Eastern Johto.
+
+## Limitations
+
+Because of how the in-game Fly map scrolls between locations, an arbitrary limitation of one flypoint per landmark was
+put in place. A landmark is a scrollable point on the map. There is generally a one-to-one correspondence between a map
+and its landmark, with the following relevant exceptions:
+- Olivine City and Olivine Port are separate maps and share the Olivine City landmark
+- Vermilion City and Vermilion Port are separate maps and share the Vermilion City landmark
+- Route 10 South and Route 10 North are separate maps and share the Route 10 landmark
+- Route 23 and Route 23 Restored are separate maps and share the Route 23 landmark
+
+When combined with Randomize Fly Unlocks set to "Exclude Silver Cave", Fly Destination 12 will be pinned to the Silver
+Cave Pokecenter.
+
+## List of maps and warps that can be used
+
+### New Bark Town
+
+- Elm's House Entrance
+- Elm's Lab Entrance
+- Player's House Entrance
+- Player's Neighbor's House Entrance
+
+### Route 29
+
+- Route 29-46 Gate South Entrance
+
+### Cherrygrove City
+
+- Cherrygrove Evolution Speech House Entrance
+- Cherrygrove Guide Gent's House Entrance
+- Cherrygrove Gym Speech House Entrance
+- Cherrygrove Mart Entrance
+- Cherrygrove Pokecenter Entrance
+- Flooded Mine South Entrance
+  - *NOTE*: This warp is only available when the Flooded Mine YAML option is enabled.
+
+### Route 30
+
+- Route 30 Berry House Entrance
+- Mr. Pokemon's House Entrance
+
+### Route 31
+
+- Dark Cave Southwest Entrance
+- Route 31 Gate East Entrance
+
+### Violet City
+
+- Route 31 Gate West Entrance
+- Sprout Tower Entrance
+- Violet Gym Entrance
+- Violet Kyle's House Entrance
+- Violet Mart Entrance
+- Violet Nickname Speech House Entrance
+- Violet Pokecenter Entrance
+- Violet Pokemon Academy Entrance
+
+### Route 32
+
+- Route 32 Gate East Entrance
+- Route 32 Pokecenter Entrance
+- Union Cave North Entrance
+- Flooded Mine North Entrance
+  - *NOTE*: This warp is only available when the Flooded Mine YAML option is enabled.
+
+### Ruins of Alph Outside
+
+- Route 32 Gate West Entrance
+- Route 36 Gate South Entrance
+- Ruins of Alph Research Center Entrance
+- Ruins of Alph Inner Chamber Entrance
+- Ruins of Alph Kabuto Chamber Entrance
+- Ruins of Alph Aerodactyl Chamber Entrance
+- Ruins of Alph Ho-Oh Chamber Entrance
+- Ruins of Alph Omanyte Chamber Entrance
+- Union Cave Ho-Oh Entrance
+- Union Cave Omanyte Entrance
+
+### Route 33
+
+- Union Cave South Entrance
+
+### Azalea Town
+
+- Azalea Charcoal Kiln Entrance
+- Azalea Gym Entrance
+- Azalea Mart Entrance
+- Azalea Pokecenter Entrance
+- Azalea-Ilex Forest Gate East Entrance
+- Kurt's House Entrance
+- Slowpoke Well Entrance
+
+### Route 34
+
+- Route 34 Daycare South Entrance
+- Route 34 Daycare West Entrance
+- Route 34-Ilex Forest Gate North Entrance
+
+### Goldenrod City
+
+- Bill's Family's House Entrance
+- Goldenrod Bike Shop Entrance
+- Goldenrod Dept. Store Entrance
+- Goldenrod Flower Shop Entrance
+- Goldenrod Game Corner Entrance
+- Goldenrod Gym Entrance
+- Goldenrod Happiness Rater Entrance
+- Goldenrod Magnet Train Station Entrance
+- Goldenrod Name Rater Entrance
+- Goldenrod PP Speech House Entrance
+- Goldenrod Pokecenter Entrance
+- Goldenrod Underground North Entrance
+- Goldenrod Underground South Entrance
+- Radio Tower Entrance
+- Route 35 Gate South Entrance
+
+### Route 35
+
+- Route 35 Gate North Entrance
+- Route 35-National Park Gate South Entrance
+
+### Route 36
+
+- Route 36 Gate North Entrance
+- Route 36-National Park Gate East Entrance
+
+### Ecruteak City
+
+- Burned Tower Entrance
+- Ecruteak Dance Theater Entrance
+- Ecruteak Gym Entrance
+- Ecruteak Itemfinder House Entrance
+- Ecruteak Lugia Speech Entrance
+- Ecruteak Mart Entrance
+- Ecruteak Pokecenter Entrance
+- Route 38 Gate East Entrance
+- Route 42 Gate West Entrance
+- Tin Tower Entrance
+- Tin Tower Gate Entrance
+- Wise Trio's Room Entrance
+
+### Tin Tower Roof
+
+- Tin Tower Roof Stairs
+
+### Route 38
+
+- Route 38 Gate West Entrance
+
+### Route 39
+
+- Moomoo Farm Barn Entrance
+- Moomoo Farm Entrance
+
+### Olivine City
+
+- Olivine Cafe Entrance
+- Olivine Fishing Guru's House Entrance
+- Olivine Gym Entrance
+- Olivine Lighthouse Entrance
+- Olivine Mart Entrance
+- Olivine Pokecenter Entrance
+- Olivine Port Passage Entrance
+- Olivine Punishment Speech House Entrance
+- Olivine Tim's House Entrance
+
+### Olivine Port
+
+- Olivine Port Stairs
+
+### Route 40
+
+- Route 40 Gate South Entrance
+
+### Battle Tower Outside
+
+- Battle Tower Entrance
+- Route 40 Gate North Entrance
+
+### Route 41
+
+- Whirl Islands Northeast Entrance
+- Whirl Islands Northwest Entrance
+- Whirl Islands Southeast Entrance
+- Whirl Islands Southwest Entrance
+
+### Cianwood City
+
+- Cianwood Gym Entrance
+- Cianwood Lugia Speech House Entrance
+- Cianwood Pharmacy Entrance
+- Cianwood Photo Studio Entrance
+- Cianwood Poke Seer's House Entrance
+- Cianwood Pokecenter Entrance
+- Mania's House Entrance
+
+### Route 42
+
+- Mount Mortar Center Entrance
+- Mount Mortar East Entrance
+- Mount Mortar West Entrance
+- Route 42 Gate East Entrance
+
+### Mahogany Town
+
+- Mahogany Gym Entrance
+- Mahogany Mart Entrance
+- Mahogany Pokecenter Entrance
+- Mahogany Red Gyarados Speech House Entrance
+- Route 43 Gate South Entrance
+
+### Route 43
+
+- Route 43 Checkpoint North Entrance
+- Route 43 Checkpoint South Entrance
+- Route 43 Gate North Entrance
+
+### Lake of Rage
+
+- Lake of Rage Hidden Power House Entrance
+- Lake of Rage Magikarp House Entrance
+
+### Route 44
+
+- Ice Path West Entrance
+
+### Blackthorn City
+
+- Blackthorn Dragon Speech House Entrance
+- Blackthorn Emy's House Entrance
+- Blackthorn Gym Entrance
+- Blackthorn Mart Entrance
+- Blackthorn Move Deleter's House Entrance
+- Blackthorn Pokecenter Entrance
+- Dragon's Den Entrance
+- Ice Path East Entrance
+
+### Route 45
+
+- Dark Cave Northeast Entrance
+
+### Route 46
+
+- Dark Cave Southeast Entrance
+- Route 29-46 Gate North Entrance
+
+### Route 27
+
+- Route 27 Sandstorm House Entrance
+- Tohjo Falls East Entrance
+- Tohjo Falls West Entrance
+
+### Route 26
+
+- Route 26 Day of Week Siblings' House Entrance
+- Route 26 Heal House Entrance
+- Victory Road Gate South Entrance
+
+### Route 28
+
+- Route 28 House Entrance
+- Victory Road Gate West Entrance
+
+### Silver Cave Outside
+
+- Silver Cave Entrance
+- Silver Cave Pokecenter Entrance
+
+### Pallet Town
+
+- Blue's House Entrance
+- Oak's Lab Entrance
+- Red's House Entrance
+
+### Viridian City
+
+- Viridian Gym Entrance
+- Viridian Mart Entrance
+- Viridian Nickname Speech House Entrance
+- Viridian Pokecenter Entrance
+- Viridian Trainer House Entrance
+
+### Route 2
+
+- Diglett's Cave North Entrance
+- Route 2 Gate North Entrance
+- Route 2 Gate South Entrance
+- Route 2 Nugget House Entrance
+
+### Pewter City
+
+- Pewter Gym Entrance
+- Pewter Mart Entrance
+- Pewter Nidoran Speech House Entrance
+- Pewter Pokecenter Entrance
+- Pewter Snooze Speech House Entrance
+
+### Route 3
+
+- Mount Moon West Entrance
+
+### Mount Moon Square
+
+- Mount Moon Gift Shop Entrance
+- Mount Moon Square North Exit
+- Mount Moon Square South Exit
+
+### Route 4
+
+- Mount Moon East Entrance
+
+### Cerulean City
+
+- Cerulean Gym Badge Speech House Entrance
+- Cerulean Gym Entrance
+- Cerulean Mart Entrance
+- Cerulean Pokecenter Entrance
+- Cerulean Police Station Entrance
+- Cerulean Trade Speech House Entrance
+
+### Route 25
+
+- Bill's House Entrance
+
+### Route 5
+
+- Route 5 Cleanse Tag House Entrance
+- Route 5 Gate North Entrance
+- Underground Path North Entrance
+
+### Route 6
+
+- Route 6 Gate South Entrance
+- Underground Path South Entrance
+
+### Vermilion City
+
+- Diglett's Cave South Entrance
+- Vermilion Diglett's Cave Speech House Entrance
+- Vermilion Fishing Speech House Entrance
+- Vermilion Gym Entrance
+- Vermilion Magnet Train Speech House Entrance
+- Vermilion Mart Entrance
+- Vermilion Pokecenter Entrance
+- Vermilion Pokemon Fan Club Entrance
+- Vermilion Port Passage Entrance
+
+### Vermilion Port
+
+- Vermilion Port Stairs
+
+### Route 9
+
+- Rock Tunnel North Entrance
+
+### Route 10 North
+
+- Power Plant Entrance
+- Route 10 Pokecenter Entrance
+
+### Route 10 South
+
+- Rock Tunnel South Entrance
+
+### Lavender Town
+
+- Lavender Mart Entrance
+- Lavender Name Rater Entrance
+- Lavender Pokecenter Entrance
+- Lavender Radio Tower Entrance
+- Lavender Soul House Entrance
+- Lavender Speech House Entrance
+- Mr. Fuji's House Entrance
+
+### Route 8
+
+- Route 8 Gate East Entrance
+- Underground Path East Entrance
+
+### Route 7
+
+- Route 7 Gate West Entrance
+- Underground Path West Entrance
+
+### Celadon City
+
+- Celadon Cafe Entrance
+- Celadon Dept. Store Entrance
+- Celadon Game Corner Entrance
+- Celadon Game Corner Prize Room Entrance
+- Celadon Gym Entrance
+- Celadon Mansion Back Entrance
+- Celadon Mansion Main Entrance
+- Celadon Pokecenter Entrance
+
+### Saffron City
+
+- Mr. Psychic's House Entrance
+- Route 5 Gate South Entrance
+- Route 6 Gate North Entrance
+- Route 7 Gate East Entrance
+- Route 8 Gate West Entrance
+- Saffron Copycat's House Entrance
+- Saffron Fighting Dojo Entrance
+- Saffron Gym Entrance
+- Saffron Magnet Train Station Entrance
+- Saffron Mart Entrance
+- Saffron Pokecenter Entrance
+- Silph Co. Entrance
+
+### Route 12
+
+- Route 12 Fishing Guru's House Entrance
+
+### Route 15
+
+- Route 15 Gate East Entrance
+
+### Fuchsia City
+
+- Bill's Brother's House Entrance
+- Fuchsia Gym Entrance
+- Fuchsia Mart Entrance
+- Fuchsia Pokecenter Entrance
+- Route 15 Gate West Entrance
+- Route 19 Gate North Entrance
+- Safari Zone Main Office Entrance
+- Safari Zone Warden's House Entrance
+
+### Route 18
+
+- Route 17-18 Gate East Entrance
+
+### Route 17
+
+- Route 17-18 Gate West Entrance
+
+### Route 16
+
+- Route 16 Gate East Entrance
+- Route 16 Gate West Entrance
+- Route 16 House Entrance
+
+### Route 19
+
+- Route 19 Gate South Entrance
+
+### Route 20
+
+- Seafoam Gym Entrance
+
+### Cinnabar Island
+
+- Cinnabar Pokecenter Entrance
+
+### Route 22
+
+- Victory Road Gate East Entrance
+
+### Route 23 Restored
+
+> [!NOTE]
+> These warps are only available when the Route 23 Restored YAML option is enabled
+
+- Victory Road Gate North Entrance
+- Victory Road South Entrance (Restored)
+
+### Route 23
+
+- Indigo Plateau Entrance
+- Victory Road North Entrance

--- a/worlds/pokemon_crystal_prerelease/fly.py
+++ b/worlds/pokemon_crystal_prerelease/fly.py
@@ -1,0 +1,155 @@
+import functools
+import logging
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+from .data import data, FlyRegion, Landmark, FlypointWarp
+from .options import FreeFlyLocation, Route32Condition, JohtoOnly, RandomizeFlyUnlocks
+from .utils import should_include_region
+
+if TYPE_CHECKING:
+    from .world import PokemonCrystalWorld
+
+
+def get_fly_regions(world: "PokemonCrystalWorld") -> list[FlyRegion]:
+    fly_regions = list(data.fly_regions)
+
+    if world.options.johto_only == JohtoOnly.option_on:
+        fly_regions = [region for region in fly_regions if region.name != "Silver Cave"]
+
+    if world.options.johto_only:
+        fly_regions = [region for region in fly_regions if region.johto]
+
+    if world.options.randomize_fly_destinations:
+        # shuffled destinations fill flypoint slots by id, so the pool has to stay contiguous
+        fly_regions = [region for region in fly_regions if region.id <= len(fly_regions)]
+
+    return fly_regions
+
+
+def get_free_fly_locations(world: "PokemonCrystalWorld"):
+    location_pool = data.fly_regions[:]
+
+    if not world.options.randomize_starting_town:
+        location_pool = \
+            [region for region in location_pool if not region.exclude_vanilla_start]
+        if world.options.route_32_condition.value != Route32Condition.option_any_badge:
+            # Azalea, Goldenrod
+            location_pool = [region for region in location_pool if region.name not in ("Azalea Town", "Goldenrod City")]
+        if not world.options.remove_ilex_cut_tree and world.options.route_32_condition.value != Route32Condition.option_any_badge:
+            # Goldenrod
+            location_pool = [region for region in location_pool if region.name != "Goldenrod City"]
+    available_regions = set(get_fly_regions(world))
+    location_pool = [region for region in location_pool if region in available_regions]
+
+    if world.options.randomize_starting_town:
+        world.options.free_fly_blocklist.value.add(world.starting_town.name)
+
+    blocklist = set(world.options.free_fly_blocklist.value)
+    if "_Johto" in blocklist:
+        blocklist.remove("_Johto")
+        blocklist.update(town.name for town in data.fly_regions if town.johto)
+    if "_Kanto" in blocklist:
+        blocklist.remove("_Kanto")
+        blocklist.update(town.name for town in data.fly_regions if not town.johto)
+
+    # only do any of this if there even is a fly location blocklist
+    if blocklist:
+
+        # figure out how many fly locations are needed
+        locations_required = 1
+        if world.options.free_fly_location.value == FreeFlyLocation.option_free_fly_and_map_card:
+            locations_required = 2
+
+        # calculate what the list of locations would be after the blocklist
+        location_pool_after_blocklist = [item for item in location_pool if
+                                         item.name not in blocklist]
+
+        # if the list after the blocked locations are removed is long enough to satisfy all the requested fly locations, set the location pool to it
+        if len(location_pool_after_blocklist) >= locations_required:
+            location_pool = location_pool_after_blocklist
+        else:
+            logging.warning("Pokemon Crystal: All valid free fly locations blocked for player %s (%s). "
+                            "Using global list instead.", world.player, world.player_name)
+
+    world.random.shuffle(location_pool)
+    if world.options.free_fly_location.value in (FreeFlyLocation.option_free_fly,
+                                                 FreeFlyLocation.option_free_fly_and_map_card):
+        world.free_fly_location = location_pool.pop()
+    if world.options.free_fly_location.value in (FreeFlyLocation.option_free_fly_and_map_card,
+                                                 FreeFlyLocation.option_map_card):
+        world.map_card_fly_location = location_pool.pop()
+
+
+@functools.cache
+def _arrival_index() -> dict[tuple[str, int], list]:
+    index = defaultdict(list)
+    for conn in data.entrance_connections.values():
+        index[(conn.arrival_map, conn.arrival_warp_index)].append(conn)
+    return index
+
+
+def flypoint_arrival_connections(flypoint: FlypointWarp) -> list:
+    """Connections whose arrival is this flypoint's warp tile."""
+    return _arrival_index().get((flypoint.map_name, flypoint.warp_index), [])
+
+
+def _get_flyable_warps() -> dict[Landmark, list[FlypointWarp]]:
+    flypoints = {
+        l: [flypoint for flypoint in flypoints if flypoint_arrival_connections(flypoint)]
+        for l, flypoints in data.flypoints.items()
+    }
+    flypoints[Landmark.NationalPark] = [
+        flypoint for flypoint in flypoints[Landmark.NationalPark]
+        if flypoint.map_name != "NationalParkBugContest"
+    ]
+    return flypoints
+
+
+def randomize_fly_destinations(world: "PokemonCrystalWorld"):
+    if world.is_universal_tracker or not world.options.randomize_fly_destinations: return
+
+    def flyable_filter(flypoint):
+        if not world.options.route_23_restored and flypoint.map_name == "Route23Restored":
+            return False
+        # A flypoint targets a specific warp tile on an outdoor map; that tile
+        # may sit in a sub-region gated by another option (e.g. the Flooded
+        # Mine entrance tile lives in REGION_CHERRYGROVE_CITY:FLOODED_MINE_
+        # ENTRANCE, which only exists when flooded_mine is on). Drop those.
+        for conn in flypoint_arrival_connections(flypoint):
+            if not should_include_region(data.regions[conn.entrance_region], world):
+                return False
+        return True
+
+    if world.options.johto_only.value == JohtoOnly.option_off:
+        eligible_landmarks = Landmark.all()
+    else:
+        eligible_landmarks = Landmark.johto_only()
+
+    num_flypoints = len(get_fly_regions(world))
+
+    if world.options.johto_only.value == JohtoOnly.option_on \
+            or world.options.randomize_fly_unlocks.value == RandomizeFlyUnlocks.option_exclude_silver_cave:
+        eligible_landmarks.remove(Landmark.Route28)
+        eligible_landmarks.remove(Landmark.SilverCave)
+        # option_on already drops Silver Cave from the pool
+        if world.options.johto_only.value != JohtoOnly.option_on:
+            num_flypoints -= 1
+
+    flyable_flypoints = {
+        l: [flypoint for flypoint in flypoints if flyable_filter(flypoint)]
+        for l, flypoints in _get_flyable_warps().items()
+    }
+    eligible_landmarks = [l for l in eligible_landmarks if len(flyable_flypoints.get(l, [])) > 0]
+    selected_landmarks = world.random.sample(eligible_landmarks, num_flypoints)
+    fly_destinations = [world.random.choice(flyable_flypoints[l]) for l in selected_landmarks]
+
+    if world.options.randomize_fly_unlocks.value == RandomizeFlyUnlocks.option_exclude_silver_cave \
+            and world.options.johto_only.value != JohtoOnly.option_on:
+        silver_index = next(fly_region.id for fly_region in data.fly_regions if fly_region.name == "Silver Cave")
+        silver_flypoint = data.flypoints[Landmark.SilverCave][0]
+        fly_destinations.insert(silver_index, silver_flypoint)
+
+    world.fly_destinations = fly_destinations
+
+

--- a/worlds/pokemon_crystal_prerelease/fly.py
+++ b/worlds/pokemon_crystal_prerelease/fly.py
@@ -136,7 +136,8 @@ def _resolve_plando_destination(destination: str, outmaps_set: set[str]) -> tupl
 
 
 def _apply_fly_destination_plando(world: "PokemonCrystalWorld",
-                                  flyable_flypoints: dict[Landmark, list[FlypointWarp]]
+                                  flyable_flypoints: dict[Landmark, list[FlypointWarp]],
+                                  limit: int
                                   ) -> dict[int, FlypointWarp]:
     """
     Returns the plandoed fly destinations and their 0-based fly unlock index
@@ -165,6 +166,12 @@ def _apply_fly_destination_plando(world: "PokemonCrystalWorld",
     outmaps_set = frozenset(OUTDOOR_WARP_MAP_FRIENDLY_NAMES)
     for key, destination in world.options.fly_destination_plando.value.items():
         index = int(key.removeprefix(FlyDestinationPlando.KEY_PREFIX)) - 1
+        if index >= limit:
+            logging.warning(f"Pokemon Crystal: Cannot fulfill {key}: {destination} as only {limit} flypoints exist "
+                            f"with these settings. "
+                            f"Ignoring key {key} in Fly Destination Plando for player {world.player_name}.")
+            continue
+
         landmark, map_name, target_flypoint = _resolve_plando_destination(destination, outmaps_set)
 
         if landmark in plandoed_landmarks:
@@ -265,9 +272,10 @@ def randomize_fly_destinations(world: "PokemonCrystalWorld"):
     }
     flyable_flypoints = {l: flypoints for l, flypoints in flyable_flypoints.items() if len(flypoints) > 0}
 
-    plando = _apply_fly_destination_plando(world, flyable_flypoints)
+    num_flypoints = len(get_fly_regions(world))
+    plando = _apply_fly_destination_plando(world, flyable_flypoints, num_flypoints)
 
-    num_flypoints = len(get_fly_regions(world)) - len(plando)
+    num_flypoints -= len(plando)
 
     _apply_fly_destination_blocklist(world, flyable_flypoints, num_flypoints)
 

--- a/worlds/pokemon_crystal_prerelease/fly.py
+++ b/worlds/pokemon_crystal_prerelease/fly.py
@@ -12,18 +12,17 @@ if TYPE_CHECKING:
     from .world import PokemonCrystalWorld
 
 
+SILVER_CAVE_FLY_INDEX = next(fr.id for fr in data.fly_regions if fr.name == "Silver Cave")
+
+
 def get_fly_regions(world: "PokemonCrystalWorld") -> list[FlyRegion]:
     fly_regions = list(data.fly_regions)
 
     if world.options.johto_only == JohtoOnly.option_on:
-        fly_regions = [region for region in fly_regions if region.name != "Silver Cave"]
+        fly_regions = [region for region in fly_regions if region.id != SILVER_CAVE_FLY_INDEX]
 
     if world.options.johto_only:
         fly_regions = [region for region in fly_regions if region.johto]
-
-    if world.options.randomize_fly_destinations:
-        # shuffled destinations fill flypoint slots by id, so the pool has to stay contiguous
-        fly_regions = [region for region in fly_regions if region.id <= len(fly_regions)]
 
     return fly_regions
 
@@ -40,10 +39,14 @@ def get_free_fly_locations(world: "PokemonCrystalWorld"):
         if not world.options.remove_ilex_cut_tree and world.options.route_32_condition.value != Route32Condition.option_any_badge:
             # Goldenrod
             location_pool = [region for region in location_pool if region.name != "Goldenrod City"]
-    available_regions = set(get_fly_regions(world))
+
+    if not world.options.randomize_fly_destinations:
+        available_regions = set(get_fly_regions(world))
+    else:
+        available_regions = set(data.fly_regions[:len(world.fly_destinations)])
     location_pool = [region for region in location_pool if region in available_regions]
 
-    if world.options.randomize_starting_town:
+    if world.options.randomize_starting_town and not world.options.randomize_fly_destinations:
         world.options.free_fly_blocklist.value.add(world.starting_town.name)
 
     blocklist = set(world.options.free_fly_blocklist.value)
@@ -148,14 +151,13 @@ def _apply_fly_destination_plando(world: "PokemonCrystalWorld",
 
     if world.options.randomize_fly_unlocks.value == RandomizeFlyUnlocks.option_exclude_silver_cave \
             and world.options.johto_only.value != JohtoOnly.option_on:
-        silver_index = next(fly_region.id for fly_region in data.fly_regions if fly_region.name == "Silver Cave")
-        silver_key = f"{FlyDestinationPlando.KEY_PREFIX}{silver_index}"
+        silver_key = f"{FlyDestinationPlando.KEY_PREFIX}{SILVER_CAVE_FLY_INDEX}"
         if silver_key in world.options.fly_destination_plando.value:
             logging.warning(f"Pokemon Crystal: Cannot plando {silver_key} as that slot is reserved for Silver Cave "
                             f"when Exclude Silver Cave is on. Removing key from Fly Destination Plando.")
             world.options.fly_destination_plando.value.pop(silver_key)
         silver_flypoint = data.flypoints[Landmark.SilverCave][0]
-        plando[silver_index] = silver_flypoint
+        plando[SILVER_CAVE_FLY_INDEX - 1] = silver_flypoint
         flyable_flypoints.pop(Landmark.Route28, None)
         flyable_flypoints.pop(Landmark.SilverCave, None)
 

--- a/worlds/pokemon_crystal_prerelease/fly.py
+++ b/worlds/pokemon_crystal_prerelease/fly.py
@@ -30,24 +30,23 @@ def get_fly_regions(world: "PokemonCrystalWorld") -> list[FlyRegion]:
 def get_free_fly_locations(world: "PokemonCrystalWorld"):
     location_pool = data.fly_regions[:]
 
-    if not world.options.randomize_starting_town:
-        location_pool = \
-            [region for region in location_pool if not region.exclude_vanilla_start]
-        if world.options.route_32_condition.value != Route32Condition.option_any_badge:
-            # Azalea, Goldenrod
-            location_pool = [region for region in location_pool if region.name not in ("Azalea Town", "Goldenrod City")]
-        if not world.options.remove_ilex_cut_tree and world.options.route_32_condition.value != Route32Condition.option_any_badge:
-            # Goldenrod
-            location_pool = [region for region in location_pool if region.name != "Goldenrod City"]
-
     if not world.options.randomize_fly_destinations:
+        if not world.options.randomize_starting_town:
+            location_pool = \
+                [region for region in location_pool if not region.exclude_vanilla_start]
+            if world.options.route_32_condition.value != Route32Condition.option_any_badge:
+                # Azalea, Goldenrod
+                location_pool = [region for region in location_pool if region.name not in ("Azalea Town", "Goldenrod City")]
+            if not world.options.remove_ilex_cut_tree and world.options.route_32_condition.value != Route32Condition.option_any_badge:
+                # Goldenrod
+                location_pool = [region for region in location_pool if region.name != "Goldenrod City"]
+        else:
+            location_pool = [region for region in location_pool if region.name != world.starting_town.name]
         available_regions = set(get_fly_regions(world))
     else:
-        available_regions = set(data.fly_regions[:len(world.fly_destinations)])
-    location_pool = [region for region in location_pool if region in available_regions]
+        available_regions = set(location_pool[:len(world.fly_destinations)])
 
-    if world.options.randomize_starting_town and not world.options.randomize_fly_destinations:
-        world.options.free_fly_blocklist.value.add(world.starting_town.name)
+    location_pool = [region for region in location_pool if region in available_regions]
 
     blocklist = set(world.options.free_fly_blocklist.value)
     if "_Johto" in blocklist:

--- a/worlds/pokemon_crystal_prerelease/fly.py
+++ b/worlds/pokemon_crystal_prerelease/fly.py
@@ -3,8 +3,9 @@ import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
-from .data import data, FlyRegion, Landmark, FlypointWarp
-from .options import FreeFlyLocation, Route32Condition, JohtoOnly, RandomizeFlyUnlocks
+from .data import data, FlyRegion, Landmark, FlypointWarp, OUTDOOR_WARP_MAP_FRIENDLY_NAMES, friendly_entrance_name, \
+    internal_entrance_name
+from .options import FreeFlyLocation, Route32Condition, JohtoOnly, RandomizeFlyUnlocks, FlyDestinationPlando
 from .utils import should_include_region
 
 if TYPE_CHECKING:
@@ -95,15 +96,152 @@ def flypoint_arrival_connections(flypoint: FlypointWarp) -> list:
 
 
 def _get_flyable_warps() -> dict[Landmark, list[FlypointWarp]]:
+    """
+    Filters the global list of flypoint warps by their presence in data.entrance_connections,
+    with which we later retreive flypoint's destination region.
+    """
     flypoints = {
         l: [flypoint for flypoint in flypoints if flypoint_arrival_connections(flypoint)]
         for l, flypoints in data.flypoints.items()
     }
+
+    # N.B. this does nothing as of 6.0.0 since National Park is excluded from ER entirely,
+    # none of its warps are in entrance_connections anyways
     flypoints[Landmark.NationalPark] = [
         flypoint for flypoint in flypoints[Landmark.NationalPark]
         if flypoint.map_name != "NationalParkBugContest"
     ]
     return flypoints
+
+
+def _resolve_plando_destination(destination: str, outmaps_set: set[str]) -> tuple[Landmark, str, FlypointWarp]:
+    """
+    Resolves a Fly Destination Plando entry, returning the following:
+    - Landmark
+    - Map name
+    - Specific Flypoint (if the entry targets a flypoint, None if it's a map)
+    """
+    if destination in outmaps_set:
+        map_name = "".join(part.title() for part in destination.split(" "))
+        landmark = data.maps[map_name].landmark
+        return landmark, map_name, None
+    else:
+        target_entrance_warps = data.entrance_connections[internal_entrance_name(destination)].exit_warps
+        map_name = target_entrance_warps[0].map_name
+        landmark = data.maps[map_name].landmark
+        target_flypoint = next(flypoint for flypoint in data.flypoints[landmark]
+                               if flypoint.warp_index in (warp.warp_index for warp in target_entrance_warps)
+                               and flypoint.map_name == map_name)
+        return landmark, map_name, target_flypoint
+
+
+def _apply_fly_destination_plando(world: "PokemonCrystalWorld",
+                                  flyable_flypoints: dict[Landmark, list[FlypointWarp]]
+                                  ) -> dict[int, FlypointWarp]:
+    """
+    Returns the plandoed fly destinations and their 0-based fly unlock index
+
+    Pops the flypoints' landmarks from flyable_flypoints to immediately filter them for regular randomization later.
+    """
+    plando = {}
+
+    if world.options.randomize_fly_unlocks.value == RandomizeFlyUnlocks.option_exclude_silver_cave \
+            and world.options.johto_only.value != JohtoOnly.option_on:
+        silver_index = next(fly_region.id for fly_region in data.fly_regions if fly_region.name == "Silver Cave")
+        silver_key = f"{FlyDestinationPlando.KEY_PREFIX}{silver_index}"
+        if silver_key in world.options.fly_destination_plando.value:
+            logging.warning(f"Pokemon Crystal: Cannot plando {silver_key} as that slot is reserved for Silver Cave "
+                            f"when Exclude Silver Cave is on. Removing key from Fly Destination Plando.")
+            world.options.fly_destination_plando.value.pop(silver_key)
+        silver_flypoint = data.flypoints[Landmark.SilverCave][0]
+        plando[silver_index] = silver_flypoint
+        flyable_flypoints.pop(Landmark.Route28, None)
+        flyable_flypoints.pop(Landmark.SilverCave, None)
+
+    if not world.options.fly_destination_plando.value:
+        return plando
+
+    plandoed_landmarks = set()
+    outmaps_set = frozenset(OUTDOOR_WARP_MAP_FRIENDLY_NAMES)
+    for key, destination in world.options.fly_destination_plando.value.items():
+        index = int(key.removeprefix(FlyDestinationPlando.KEY_PREFIX)) - 1
+        landmark, map_name, target_flypoint = _resolve_plando_destination(destination, outmaps_set)
+
+        if landmark in plandoed_landmarks:
+            logging.warning(f"Pokemon Crystal: Cannot fulfill {key}: {destination} as its landmark is already taken. "
+                            f"Ignoring key {key} in Fly Destination Plando for player {world.player_name}.")
+            continue
+
+        if target_flypoint is not None and target_flypoint not in flyable_flypoints.get(landmark, []):
+            logging.warning(f"Pokemon Crystal: Cannot fulfill {key}: {destination} as the destination is unavailable "
+                            f"under these settings. Ignoring key {key} in Fly Destination Plando for player "
+                            f"{world.player_name}.")
+            continue
+
+        if target_flypoint is None:
+            potential_dests = {flypoint for flypoint in flyable_flypoints[landmark] if flypoint.map_name == map_name}
+            if len(potential_dests) == 0:
+                logging.warning(f"Pokemon Crystal: cannot fulfill {key}: {destination} as no flypoints in that map "
+                                f"are available under these settings. Ignoring key {key} in Fly Destination Plando "
+                                f"for player {world.player_name}.")
+                continue
+
+            # Prefer non-blocklisted warps if one is available
+            blocklisted_conns = {conn for name, conn in data.entrance_connections.items()
+                                 if conn.exit_warps[0].map_name == map_name
+                                 and friendly_entrance_name(name) in world.options.fly_destination_blocklist.value}
+            blocklisted_dests = {flypoint for flypoint in potential_dests
+                                 if any(conn for conn in blocklisted_conns
+                                        if flypoint.warp_index in (warp.warp_index for warp in conn.exit_warps)
+                                        )
+                                 }
+            non_blocklisted = potential_dests - blocklisted_dests
+            if non_blocklisted:
+                potential_dests = non_blocklisted
+            target_flypoint = world.random.choice(sorted(potential_dests, key=lambda fw: fw.warp_index))
+
+        plandoed_landmarks.add(landmark)
+        flyable_flypoints.pop(landmark)
+        plando[index] = target_flypoint
+
+    return plando
+
+
+def _apply_fly_destination_blocklist(world: "PokemonCrstalWorld",
+                                     flyable_flypoints: dict[Landmark, list[FlypointWarp]],
+                                     num_flypoints: int):
+    """
+    Removes blocklisted flypoints from flyable_flypoints while ensuring len(flyable_flypoints) >= num_flypoints
+    """
+    if not world.options.fly_destination_blocklist.value: return
+
+    outmaps_set = frozenset(OUTDOOR_WARP_MAP_FRIENDLY_NAMES)
+    blocklist = {_resolve_plando_destination(dest, outmaps_set)
+                 for dest in world.options.fly_destination_blocklist.value}
+    blocklisted_per_landmark = defaultdict(set)
+    for dest in blocklist:
+        if len(flyable_flypoints.get(dest[0], [])) == 0: continue
+        if dest[2] is not None:
+            blocklisted_per_landmark[dest[0]].add(dest[2])
+        else:
+            blocklisted_per_landmark[dest[0]] |= {flypoint for flypoint in flyable_flypoints[dest[0]]
+                                                  if flypoint.map_name == dest[1]}
+
+    blocklisted_landmarks = set()
+    for landmark, blocked in blocklisted_per_landmark.items():
+        blocked &= set(flyable_flypoints[landmark])
+        if len(blocked) == len(flyable_flypoints[landmark]):
+            blocklisted_landmarks.add(landmark)
+
+    remaining = len(flyable_flypoints) - len(blocklisted_landmarks)
+    if remaining < num_flypoints:
+        loosen = world.random.sample(sorted(blocklisted_landmarks), num_flypoints - remaining)
+        for landmark in loosen:
+            blocklisted_per_landmark.pop(landmark)
+
+    for landmark, blocked in blocklisted_per_landmark.items():
+        for flypoint in blocked:
+            flyable_flypoints[landmark].remove(flypoint)
 
 
 def randomize_fly_destinations(world: "PokemonCrystalWorld"):
@@ -121,35 +259,23 @@ def randomize_fly_destinations(world: "PokemonCrystalWorld"):
                 return False
         return True
 
-    if world.options.johto_only.value == JohtoOnly.option_off:
-        eligible_landmarks = Landmark.all()
-    else:
-        eligible_landmarks = Landmark.johto_only()
-
-    num_flypoints = len(get_fly_regions(world))
-
-    if world.options.johto_only.value == JohtoOnly.option_on \
-            or world.options.randomize_fly_unlocks.value == RandomizeFlyUnlocks.option_exclude_silver_cave:
-        eligible_landmarks.remove(Landmark.Route28)
-        eligible_landmarks.remove(Landmark.SilverCave)
-        # option_on already drops Silver Cave from the pool
-        if world.options.johto_only.value != JohtoOnly.option_on:
-            num_flypoints -= 1
-
     flyable_flypoints = {
         l: [flypoint for flypoint in flypoints if flyable_filter(flypoint)]
         for l, flypoints in _get_flyable_warps().items()
     }
-    eligible_landmarks = [l for l in eligible_landmarks if len(flyable_flypoints.get(l, [])) > 0]
+    flyable_flypoints = {l: flypoints for l, flypoints in flyable_flypoints.items() if len(flypoints) > 0}
+
+    plando = _apply_fly_destination_plando(world, flyable_flypoints)
+
+    num_flypoints = len(get_fly_regions(world)) - len(plando)
+
+    _apply_fly_destination_blocklist(world, flyable_flypoints, num_flypoints)
+
+    eligible_landmarks = [l for l, flypoints in flyable_flypoints.items() if len(flypoints) > 0]
     selected_landmarks = world.random.sample(eligible_landmarks, num_flypoints)
     fly_destinations = [world.random.choice(flyable_flypoints[l]) for l in selected_landmarks]
 
-    if world.options.randomize_fly_unlocks.value == RandomizeFlyUnlocks.option_exclude_silver_cave \
-            and world.options.johto_only.value != JohtoOnly.option_on:
-        silver_index = next(fly_region.id for fly_region in data.fly_regions if fly_region.name == "Silver Cave")
-        silver_flypoint = data.flypoints[Landmark.SilverCave][0]
-        fly_destinations.insert(silver_index, silver_flypoint)
+    for index, flypoint in sorted(plando.items()):
+        fly_destinations.insert(index, flypoint)
 
     world.fly_destinations = fly_destinations
-
-

--- a/worlds/pokemon_crystal_prerelease/item_data.py
+++ b/worlds/pokemon_crystal_prerelease/item_data.py
@@ -2,6 +2,9 @@ POKEDEX_OFFSET = 10000
 POKEDEX_COUNT_OFFSET = 20000
 GRASS_OFFSET = 30000
 FLAG_ITEM_OFFSET = 512
+# Some items are effectively the same but with a different name in a different context; & this mask onto an item code
+# to resolve its in-game ID
+CANONICAL_ITEM_ID_MASK = 0x3ff
 
 # AP_Start_Inventory is a 384 byte table of 3 byte entries; pocket sizes come from data.json
 START_INVENTORY_ENTRIES = 128

--- a/worlds/pokemon_crystal_prerelease/locations.py
+++ b/worlds/pokemon_crystal_prerelease/locations.py
@@ -6,6 +6,7 @@ from .battle_tower_data import BATTLE_TOWER_TRAINERS, BATTLE_TOWER_TIER_OFFSET, 
     BATTLE_TOWER_TRAINER_OFFSET, BATTLE_TOWER_TRAINERS_PER_TIER
 from .data import data, LogicalAccess, GrassTile
 from .evolution import evolution_location_name
+from .fly import get_fly_regions
 from .item_data import POKEDEX_OFFSET, POKEDEX_COUNT_OFFSET, GRASS_OFFSET, FLAG_ITEM_OFFSET
 from .items import item_const_name_to_id
 from .options import Goal, DexsanityStarters, Grasssanity, RandomizeBugCatchingContest, WildEncounterMethodsRequired, \
@@ -14,7 +15,7 @@ from .pokemon import get_priority_dexsanity, get_excluded_dexsanity
 from .rematch_trainer_data import (
     all_rematch_locations
 )
-from .utils import get_fly_regions, get_mart_slot_location_name
+from .utils import get_mart_slot_location_name
 
 if TYPE_CHECKING:
     from . import PokemonCrystalWorld

--- a/worlds/pokemon_crystal_prerelease/locations.py
+++ b/worlds/pokemon_crystal_prerelease/locations.py
@@ -6,11 +6,11 @@ from .battle_tower_data import BATTLE_TOWER_TRAINERS, BATTLE_TOWER_TIER_OFFSET, 
     BATTLE_TOWER_TRAINER_OFFSET, BATTLE_TOWER_TRAINERS_PER_TIER
 from .data import data, LogicalAccess, GrassTile
 from .evolution import evolution_location_name
-from .fly import get_fly_regions
-from .item_data import POKEDEX_OFFSET, POKEDEX_COUNT_OFFSET, GRASS_OFFSET, FLAG_ITEM_OFFSET
+from .fly import get_fly_regions, SILVER_CAVE_FLY_INDEX
+from .item_data import POKEDEX_OFFSET, POKEDEX_COUNT_OFFSET, GRASS_OFFSET, FLAG_ITEM_OFFSET, CANONICAL_ITEM_ID_MASK
 from .items import item_const_name_to_id
 from .options import Goal, DexsanityStarters, Grasssanity, RandomizeBugCatchingContest, WildEncounterMethodsRequired, \
-    PokemonSourceLogic, BattleTowerSanity, VanillaEventChains
+    PokemonSourceLogic, BattleTowerSanity, VanillaEventChains, RandomizeFlyUnlocks, JohtoOnly
 from .pokemon import get_priority_dexsanity, get_excluded_dexsanity
 from .rematch_trainer_data import (
     all_rematch_locations
@@ -346,7 +346,16 @@ def create_locations(world: "PokemonCrystalWorld", regions: dict[str, Region]) -
 
     if world.options.randomize_fly_unlocks or world.options.remote_items:
 
-        for fly_region in get_fly_regions(world):
+        if world.options.randomize_fly_destinations:
+            default_fly_item = lambda idx, fr: ((CANONICAL_ITEM_ID_MASK + 1) | (FLAG_ITEM_OFFSET + idx)
+                    if fr.id != SILVER_CAVE_FLY_INDEX or
+                        (world.options.randomize_fly_unlocks.value != RandomizeFlyUnlocks.option_exclude_silver_cave
+                         and world.options.johto_only.value != JohtoOnly.option_on)
+                    else FLAG_ITEM_OFFSET + fr.id)
+        else:
+            default_fly_item = lambda _, fr: FLAG_ITEM_OFFSET + fr.id
+
+        for i, fly_region in enumerate(get_fly_regions(world)):
             parent_region = regions[fly_region.unlock_region]
 
             location = PokemonCrystalLocation(
@@ -356,7 +365,7 @@ def create_locations(world: "PokemonCrystalWorld", regions: dict[str, Region]) -
                 tags=frozenset({"fly"}),
                 flag=data.event_flags[f"EVENT_VISITED_{fly_region.base_identifier}"],
                 rom_addresses=[data.rom_addresses[f"AP_FlyUnlock_{fly_region.base_identifier}"]],
-                default_item_value=FLAG_ITEM_OFFSET + fly_region.id
+                default_item_value=default_fly_item(i+1, fly_region)
             )
 
             parent_region.locations.append(location)

--- a/worlds/pokemon_crystal_prerelease/options.py
+++ b/worlds/pokemon_crystal_prerelease/options.py
@@ -10,7 +10,8 @@ from Options import Toggle, Choice, DefaultOnToggle, Range, PerGameCommonOptions
     StartInventoryPool, OptionDict, Visibility, DeathLink, OptionGroup, OptionList, FreeText, OptionError, \
     OptionCounter, PlandoConnections, TextChoice
 from Utils import is_iterable_except_str
-from .data import data, MapPalette, MiscOption, friendly_entrance_name
+from .data import data, MapPalette, MiscOption, friendly_entrance_name, FRIENDLY_CONNECTION_NAMES, \
+    OUTDOOR_WARP_MAP_FRIENDLY_NAMES, OUTDOOR_ENVIRONMENTS
 from .maps import FLASH_MAP_GROUPS
 from .pokemon_data import LEGENDARY_POKEMON, NON_LEGENDARY_POKEMON
 from .entrance_rando import ENTRANCE_CATEGORIES
@@ -81,6 +82,39 @@ class PokemonSet(OptionSet):
                        pokemon_data.friendly_name in pokemon}
 
         return pokemon_ids
+
+
+class WeightedOptionDict(OptionDict):
+    valid_values: set[str]
+
+    def __init__(self, value):
+        rolled = {}
+        for k, v in value.items():
+            if isinstance(v, dict):
+                invalid = set(v.keys()) - self.valid_values
+                if invalid:
+                    raise OptionError(
+                        f"Found unexpected value(s) {', '.join(sorted(invalid))} in {self.display_name}. "
+                        f"Allowed values: {self.valid_values}."
+                    )
+                rolled[k] = random.choices(list(v.keys()), weights=list(v.values()))[0]
+            else:
+                rolled[k] = v
+        super().__init__(rolled)
+
+    def verify_keys(self) -> None:
+        extra_keys = {str(k) for k in self.value.keys()} - self._valid_keys
+        if extra_keys:
+            raise OptionError(
+                f"Found unexpected key {', '.join(extra_keys)} in {self.display_name}. "
+                f"Allowed keys: {self._valid_keys}."
+            )
+        extra_values = set(self.value.values()) - self.valid_values
+        if extra_values:
+            raise OptionError(
+                f"Found unexpected value {', '.join(extra_values)} in {self.display_name}. "
+                f"Allowed values: {self.valid_values}."
+            )
 
 
 class Goal(EnhancedOptionSet):
@@ -1146,6 +1180,39 @@ class RandomizeFlyDestinations(Toggle):
     display_name = "Randomize Fly Destinations"
 
 
+_VALID_FLY_DESTINATION_KEYS = sorted(
+    friendly_name for conn, friendly_name in FRIENDLY_CONNECTION_NAMES.items()
+    if conn in data.entrance_connections and
+    data.maps[data.entrance_connections[conn].exit_warps[0].map_name].environment in OUTDOOR_ENVIRONMENTS
+) + OUTDOOR_WARP_MAP_FRIENDLY_NAMES
+
+
+class FlyDestinationBlocklist(OptionSet):
+    """
+    Prevents a specific warp or map from being selected as a random flypoint.
+
+    You can find a complete list of accepted values at:
+    https://github.com/gerbiljames/Archipelago-Crystal/blob/pokecrystal/worlds/pokemon_crystal/docs/fly_plando.md
+    """
+    display_name = "Fly Destination Blocklist"
+    valid_keys = _VALID_FLY_DESTINATION_KEYS
+    default = []
+
+
+class FlyDestinationPlando(WeightedOptionDict):
+    """
+    Pins one or more fly unlock to a specific warp or map.
+
+    You can find a guide to accepted values and formatting at:
+    https://github.com/gerbiljames/Archipelago-Crystal/blob/pokecrystal/worlds/pokemon_crystal/docs/fly_plando.md
+    """
+    KEY_PREFIX = "Fly Destination "
+    display_name = "Fly Destination Plando"
+    valid_keys = sorted(f"Fly Destination {i}" for i in range(1, len(data.fly_regions) + 1))
+    valid_values = frozenset(_VALID_FLY_DESTINATION_KEYS)
+    default = {}
+
+
 class RandomizeBugCatchingContest(Choice):
     """
     Shuffles the bug catching contest prizes into the pool
@@ -1754,7 +1821,7 @@ _ignored_tm_moves = ("NO_MOVE", "STRUGGLE", "HEADBUTT", "ROCK_SMASH", "CUT", "FL
                      "WHIRLPOOL", "WATERFALL")
 
 
-class TMPlando(OptionDict):
+class TMPlando(WeightedOptionDict):
     """
     Specify what move a TM will contain.
     TMs 02 and 08 can never be plandoed. This also means Headbutt and Rock Smash cannot be plandoed onto other TMs.
@@ -1776,33 +1843,8 @@ class TMPlando(OptionDict):
         sorted(move.name.title() for id, move in data.moves.items() if id not in _ignored_tm_moves))
 
     def __init__(self, value):
-        normalized = {}
-        for k, v in sorted(value.items()):
-            if isinstance(v, dict):
-                invalid = set(v.keys()) - self.valid_values
-                if invalid:
-                    raise OptionError(
-                        f"Found unexpected move(s) {', '.join(sorted(invalid))} in {self.display_name}. "
-                        f"Move names should be in Title Case, e.g. 'Ice Beam'."
-                    )
-                normalized[int(k)] = random.choices(list(v.keys()), weights=list(v.values()))[0]
-            else:
-                normalized[int(k)] = v
+        normalized = {int(k): v for k, v in sorted(value.items())}
         super().__init__(normalized)
-
-    def verify_keys(self) -> None:
-        extra_keys = {str(k) for k in self.value.keys()} - self._valid_keys
-        if extra_keys:
-            raise OptionError(
-                f"Found unexpected key {', '.join(extra_keys)} in {self.display_name}. "
-                f"Allowed keys: {self._valid_keys}."
-            )
-        extra_values = set(self.value.values()) - self.valid_values
-        if extra_values:
-            raise OptionError(
-                f"Found unexpected value {', '.join(extra_values)} in {self.display_name}. "
-                f"Allowed values: {self.valid_values}."
-            )
 
 
 class TMSameTypeCompatibility(NamedRange):
@@ -3153,6 +3195,8 @@ class PokemonCrystalOptions(PerGameCommonOptions):
     coupled_entrances: CoupledEntrances
     plando_connections: CrystalPlandoConnections
     randomize_fly_destinations: RandomizeFlyDestinations
+    fly_destination_blocklist: FlyDestinationBlocklist
+    fly_destination_plando: FlyDestinationPlando
 
 
 OPTION_GROUPS = [
@@ -3165,6 +3209,8 @@ OPTION_GROUPS = [
          MixEntrances,
          CoupledEntrances,
          RandomizeFlyDestinations,
+         FlyDestinationBlocklist,
+         FlyDestinationPlando,
          CrystalPlandoConnections,
          FloodedMine,
          Route23Restored]

--- a/worlds/pokemon_crystal_prerelease/regions.py
+++ b/worlds/pokemon_crystal_prerelease/regions.py
@@ -6,13 +6,14 @@ from BaseClasses import Region, ItemClassification
 from entrance_rando import EntranceType
 from .data import data, RegionData, EncounterMon, StaticPokemon, LogicalAccess, EncounterKey, FishingRodType, \
     TreeRarity, EncounterType
+from .fly import flypoint_arrival_connections, get_fly_regions
 from .items import PokemonCrystalItem
 from .locations import PokemonCrystalLocation
 from .options import FreeFlyLocation, JohtoOnly, BlackthornDarkCaveAccess, Goal, Route42Access, LevelCurve, \
     WildEncounterMethodsRequired
 from .pokemon_data import SWARM_REGISTRATIONS
 from .entrance_rando import build_er_group_lookup, base_category, connection_er_group
-from .utils import flypoint_arrival_connections, get_fly_regions, should_include_region
+from .utils import should_include_region
 
 if TYPE_CHECKING:
     from .world import PokemonCrystalWorld

--- a/worlds/pokemon_crystal_prerelease/rom.py
+++ b/worlds/pokemon_crystal_prerelease/rom.py
@@ -1829,7 +1829,7 @@ def generate_output(world: "PokemonCrystalWorld", output_directory: str, patch: 
             group, map_id = data.map_constants[map_const]
             write_bytes([group, map_id, x, y], post_flypoint_base + index * 4)
 
-    if world.options.randomize_fly_unlocks or world.options.remote_items:
+    if world.options.randomize_fly_unlocks or world.options.remote_items or world.options.randomize_fly_destinations:
         write_bytes([1], data.rom_addresses["AP_Setting_FlyUnlocksShuffled"] + 2)
 
     if world.options.enforce_wild_encounter_methods_logic:
@@ -2122,6 +2122,13 @@ def generate_output(world: "PokemonCrystalWorld", output_directory: str, patch: 
             write_bytes([landmark, i - 1], data.rom_addresses[f"AP_Flypoint_{flytable_index}"])
 
             write_bytes(convert_to_ingame_text(f"FLY UNLOCK {i}", True), data.rom_addresses[f"AP_Flypoint_{i}_Name"])
+
+        if not (world.options.randomize_fly_unlocks or world.options.remote_items):
+            flag_item_byte = [item_const_name_to_id("FLAG_ITEM")]
+            for fly_region in data.fly_regions:
+                write_bytes(flag_item_byte, data.rom_addresses[f"AP_FlyUnlock_{fly_region.base_identifier}"])
+                event_flag = data.event_flags[f"EVENT_VISITED_{fly_region.base_identifier}"]
+                write_bytes([fly_region.id], data.rom_addresses["AP_Setting_FlagItems_Table_Events"] + event_flag)
 
 
     patch.write_file("token_data.bin", patch.get_token_binary())

--- a/worlds/pokemon_crystal_prerelease/rom.py
+++ b/worlds/pokemon_crystal_prerelease/rom.py
@@ -22,7 +22,7 @@ from .evolution import get_pokemon_evolutions
 from .battle_tower_data import BATTLE_TOWER_TIER_OFFSET, BATTLE_TOWER_NUM_TIERS, BATTLE_TOWER_TRAINER_OFFSET, \
     BATTLE_TOWER_NUM_TRAINERS, BATTLE_TOWER_TRAINERS_PER_TIER
 from .rematch_trainer_data import REMATCH_TRAINER_LOCATION_BASE, NUM_REMATCH_TRAINER_LOCATIONS
-from .item_data import POKEDEX_COUNT_OFFSET, POKEDEX_OFFSET, GRASS_OFFSET
+from .item_data import POKEDEX_COUNT_OFFSET, POKEDEX_OFFSET, GRASS_OFFSET, CANONICAL_ITEM_ID_MASK
 from .items import item_const_name_to_id
 from .maps import FLASH_MAP_GROUPS
 from .options import UndergroundsRequirePower, RequireItemfinder, Goal, VanillaEventChains, Route2Access, Route42Access, \
@@ -749,7 +749,7 @@ def generate_output(world: "PokemonCrystalWorld", output_directory: str, patch: 
             location_addresses = location.rom_addresses
 
         if not world.options.remote_items and location.item and location.item.player == world.player:
-            item_id = location.item.code
+            item_id = location.item.code & CANONICAL_ITEM_ID_MASK
             if location.item.flag_index is not None:
                 write_item(item_const_name_to_id("FLAG_ITEM"), location_addresses)
 
@@ -1633,7 +1633,7 @@ def generate_output(world: "PokemonCrystalWorld", output_directory: str, patch: 
             item_code = item_const_name_to_id("FLAG_ITEM")
             flag_index = item.flag_index
         else:
-            item_code = item.code
+            item_code = item.code & CANONICAL_ITEM_ID_MASK
             flag_index = 0
 
         while quantity:

--- a/worlds/pokemon_crystal_prerelease/rules.py
+++ b/worlds/pokemon_crystal_prerelease/rules.py
@@ -11,6 +11,7 @@ from .logic_rules import HasNPokemon, HasDexCount, HasSpeciesDex, HasRequestSlot
 from .data import data, EvolutionType, EvolutionData, FishingRodType, EncounterKey, LogicalAccess, EncounterType, \
     FishTimeOfDay
 from .evolution import evolution_location_name
+from .fly import get_fly_regions
 from .items import item_const_name_to_label
 from .options import Goal, JohtoOnly, Route32Condition, UndergroundsRequirePower, Route2Access, \
     BlackthornDarkCaveAccess, NationalParkAccess, Route22AccessRequirement, Route3Access, BreedingMethodsRequired, \
@@ -23,7 +24,7 @@ from .options import Goal, JohtoOnly, Route32Condition, UndergroundsRequirePower
 from .pokemon import add_hm_compatibility, get_chamber_event_for_unown
 from .pokemon_data import ALL_UNOWN, SWARM_REGISTRATIONS
 from .rematch_trainer_data import REMATCH_TRAINERS, SCALING_SUFFIX, rematch_location_name
-from .utils import get_fly_regions, get_mart_slot_location_name
+from .utils import get_mart_slot_location_name
 
 if TYPE_CHECKING:
     from .world import PokemonCrystalWorld

--- a/worlds/pokemon_crystal_prerelease/rules.py
+++ b/worlds/pokemon_crystal_prerelease/rules.py
@@ -11,7 +11,7 @@ from .logic_rules import HasNPokemon, HasDexCount, HasSpeciesDex, HasRequestSlot
 from .data import data, EvolutionType, EvolutionData, FishingRodType, EncounterKey, LogicalAccess, EncounterType, \
     FishTimeOfDay
 from .evolution import evolution_location_name
-from .fly import get_fly_regions
+from .fly import get_fly_regions, SILVER_CAVE_FLY_INDEX
 from .items import item_const_name_to_label
 from .options import Goal, JohtoOnly, Route32Condition, UndergroundsRequirePower, Route2Access, \
     BlackthornDarkCaveAccess, NationalParkAccess, Route22AccessRequirement, Route3Access, BreedingMethodsRequired, \
@@ -20,7 +20,7 @@ from .options import Goal, JohtoOnly, Route32Condition, UndergroundsRequirePower
     Route44AccessRequirement, RandomizeBadges, RadioTowerRequirement, PokemonCrystalOptions, Shopsanity, \
     RequireItemfinder, Route42Access, RedGyaradosAccess, PhoneCallMode, Route30Access, \
     SouthKantoCondition, RemoveBadgeRequirement, WildEncounterMethodsRequired, SaffronGatehouseTea, \
-    VanillaEventChains
+    VanillaEventChains, RandomizeFlyUnlocks
 from .pokemon import add_hm_compatibility, get_chamber_event_for_unown
 from .pokemon_data import ALL_UNOWN, SWARM_REGISTRATIONS
 from .rematch_trainer_data import REMATCH_TRAINERS, SCALING_SUFFIX, rematch_location_name
@@ -579,8 +579,12 @@ def set_rules(world: "PokemonCrystalWorld") -> None:
 
     if world.options.randomize_fly_destinations:
         for i, flypoint in enumerate(world.fly_destinations, start=1):
-            fly_region = next(fr for fr in data.fly_regions if fr.id == i)
-            set_rule(get_entrance(f"Fly Destination {i}"), fly_unlock_rule(fly_region))
+            if i == SILVER_CAVE_FLY_INDEX and \
+                    world.options.randomize_fly_unlocks.value == RandomizeFlyUnlocks.option_exclude_silver_cave and \
+                    world.options.johto_only.value != JohtoOnly.option_on:
+                set_rule(get_entrance(f"Fly Destination {i}"), Has(f"Fly Silver Cave"))
+            else:
+                set_rule(get_entrance(f"Fly Destination {i}"), Has(f"Fly Unlock {i}"))
 
     # New Bark Town
     set_rule(get_entrance("REGION_NEW_BARK_TOWN -> REGION_ROUTE_27:WEST"), CanUseHM(CanUseHM.SURF))

--- a/worlds/pokemon_crystal_prerelease/test/test_fly_destination_plando.py
+++ b/worlds/pokemon_crystal_prerelease/test/test_fly_destination_plando.py
@@ -6,11 +6,12 @@ class FriendlyMapNamesTest(PokemonCrystalTestBase):
     def test_friendly_map_names_match(self):
         """Prevent data drift by checking that the list of friendly map names in data corresponds exactly
         to the flypoints' maps."""
-        from ..data import OUTDOOR_WARP_MAP_FRIENDLY_NAMES, data
+        from ..data import OUTDOOR_WARP_MAP_FRIENDLY_NAMES
+        from ..fly import _get_flyable_warps
         internal_map_names = {"".join(part.title() for part in name.split(" "))
                               for name in OUTDOOR_WARP_MAP_FRIENDLY_NAMES}
         flypoint_maps = set()
-        for flypoints in data.flypoints.values():
+        for flypoints in _get_flyable_warps().values():
             flypoint_maps |= {flypoint.map_name for flypoint in flypoints}
         self.assertEqual(internal_map_names, flypoint_maps)
 

--- a/worlds/pokemon_crystal_prerelease/test/test_fly_destination_plando.py
+++ b/worlds/pokemon_crystal_prerelease/test/test_fly_destination_plando.py
@@ -1,0 +1,32 @@
+from .bases import PokemonCrystalTestBase
+
+class FriendlyMapNamesTest(PokemonCrystalTestBase):
+    options = {}
+
+    def test_friendly_map_names_match(self):
+        """Prevent data drift by checking that the list of friendly map names in data corresponds exactly
+        to the flypoints' maps."""
+        from ..data import OUTDOOR_WARP_MAP_FRIENDLY_NAMES, data
+        internal_map_names = {"".join(part.title() for part in name.split(" "))
+                              for name in OUTDOOR_WARP_MAP_FRIENDLY_NAMES}
+        flypoint_maps = {flypoint.map_name for flypoint in data.flypoints.values()}
+        self.assertEqual(internal_map_names, flypoint_maps)
+
+class FlyDestinationPlandoTest(PokemonCrystalTestBase):
+    options = {
+        "randomize_fly_destinations": "true",
+        "fly_destination_plando": {
+            "Fly Destination 1": "Route 30"
+        },
+        "fly_destination_blocklist": ["Route 30 Berry House Entrance"]
+    }
+
+    def test_plando_map_ignores_blocklisted_warps(self):
+        """Check that a combination of plandoing a map and blocklisting some warps on that map
+        filters out the blocklisted warps while keeping a flypoint on that map"""
+        from ..data import data
+        # Route 30 has only 2 warps, and we blocklisted the Berry House,
+        # so Fly Destination 1 should always be Mr. Pokemon's House
+        mr_pokemons_house_warp = data.entrance_connections["REGION_ROUTE_30 -> REGION_MR_POKEMONS_HOUSE"].exit_warps[0]
+        self.assertEqual((self.fly_destinations[0].map_name, self.fly_destinations[0].warp_index),
+                         (mr_pokemons_house_warp.map_name, mr_pokemons_house_warp.warp_index))

--- a/worlds/pokemon_crystal_prerelease/test/test_fly_destination_plando.py
+++ b/worlds/pokemon_crystal_prerelease/test/test_fly_destination_plando.py
@@ -9,7 +9,9 @@ class FriendlyMapNamesTest(PokemonCrystalTestBase):
         from ..data import OUTDOOR_WARP_MAP_FRIENDLY_NAMES, data
         internal_map_names = {"".join(part.title() for part in name.split(" "))
                               for name in OUTDOOR_WARP_MAP_FRIENDLY_NAMES}
-        flypoint_maps = {flypoint.map_name for flypoint in data.flypoints.values()}
+        flypoint_maps = set()
+        for flypoints in data.flypoints.values():
+            flypoint_maps |= {flypoint.map_name for flypoint in flypoints}
         self.assertEqual(internal_map_names, flypoint_maps)
 
 class FlyDestinationPlandoTest(PokemonCrystalTestBase):
@@ -27,6 +29,7 @@ class FlyDestinationPlandoTest(PokemonCrystalTestBase):
         from ..data import data
         # Route 30 has only 2 warps, and we blocklisted the Berry House,
         # so Fly Destination 1 should always be Mr. Pokemon's House
+        flypoint_1 = self.world.fly_destinations[0]
         mr_pokemons_house_warp = data.entrance_connections["REGION_ROUTE_30 -> REGION_MR_POKEMONS_HOUSE"].exit_warps[0]
-        self.assertEqual((self.fly_destinations[0].map_name, self.fly_destinations[0].warp_index),
+        self.assertEqual((flypoint_1.map_name, flypoint_1.warp_index),
                          (mr_pokemons_house_warp.map_name, mr_pokemons_house_warp.warp_index))

--- a/worlds/pokemon_crystal_prerelease/test/test_indigo_flypoint.py
+++ b/worlds/pokemon_crystal_prerelease/test/test_indigo_flypoint.py
@@ -91,9 +91,12 @@ class IndigoFlyDestinationsJohtoOnlyTest(PokemonCrystalTestBase):
 
     def test_slots_stay_contiguous(self):
         from ..fly import get_fly_regions
+        from ..data import data
         fly_regions = get_fly_regions(self.world)
         self.assertEqual(len(self.world.fly_destinations), len(fly_regions))
-        self.assertEqual([fr.id for fr in fly_regions], list(range(1, len(fly_regions) + 1)))
+        # Johto is contiguous, up until Indigo which is last
+        self.assertEqual([fr.id for fr in fly_regions], list(range(1, len(fly_regions))) +
+                                                            [max(fr.id for fr in data.fly_regions)])
 
 
 class IndigoBlocklistAcceptsIndigoTest(PokemonCrystalTestBase):

--- a/worlds/pokemon_crystal_prerelease/test/test_indigo_flypoint.py
+++ b/worlds/pokemon_crystal_prerelease/test/test_indigo_flypoint.py
@@ -90,7 +90,7 @@ class IndigoFlyDestinationsJohtoOnlyTest(PokemonCrystalTestBase):
             self.assertLess(fly_location.spawn_flag, len(self.world.fly_destinations))
 
     def test_slots_stay_contiguous(self):
-        from ..utils import get_fly_regions
+        from ..fly import get_fly_regions
         fly_regions = get_fly_regions(self.world)
         self.assertEqual(len(self.world.fly_destinations), len(fly_regions))
         self.assertEqual([fr.id for fr in fly_regions], list(range(1, len(fly_regions) + 1)))

--- a/worlds/pokemon_crystal_prerelease/utils.py
+++ b/worlds/pokemon_crystal_prerelease/utils.py
@@ -1,4 +1,3 @@
-import functools
 import logging
 from collections import defaultdict
 from collections.abc import Mapping
@@ -6,18 +5,18 @@ from math import ceil
 from typing import TYPE_CHECKING
 
 from Options import OptionError, Toggle
-from .data import data, StartingTown, FlyRegion, RegionData, Landmark, FlypointWarp
+from .data import data, StartingTown, RegionData
 from .item_data import START_INVENTORY_ENTRIES
 from .items import item_const_name_to_label
 from .mart_data import CUSTOM_MART_SLOT_NAMES
-from .options import FreeFlyLocation, Route32Condition, JohtoOnly, RandomizeBadges, UndergroundsRequirePower, \
-    Route3Access, VictoryRoadRequirement, EliteFourRequirement, Goal, Route44AccessRequirement, BlackthornDarkCaveAccess, RedRequirement, \
+from .options import JohtoOnly, RandomizeBadges, UndergroundsRequirePower, Route3Access, VictoryRoadRequirement, \
+    EliteFourRequirement, Goal, Route44AccessRequirement, BlackthornDarkCaveAccess, RedRequirement, \
     MtSilverRequirement, HMBadgeRequirements, RedGyaradosAccess, EarlyFly, RadioTowerRequirement, \
     BreedingMethodsRequired, Shopsanity, KantoTrainersanity, JohtoTrainersanity, RandomizePokemonRequests, \
     RandomizeTypes, RandomizeEvolution, RandomizeTrades, TradesRequired, MagnetTrainAccess, \
     Dexsanity, EncounterGrouping, SouthKantoAccess, SouthKantoCondition, LevelScaling, LockKantoGyms, \
-    WildEncounterMethodsRequired, RemoveBadgeRequirement, SaffronGatehouseTea, EvolutionMethodsRequired, \
-    RandomizeFlyUnlocks, PokemonSourceLogic, RandomizePokedex, RandomizeLuckyNumberShow, VanillaEventChains
+    WildEncounterMethodsRequired, RemoveBadgeRequirement, SaffronGatehouseTea, PokemonSourceLogic, \
+    RandomizePokedex, RandomizeLuckyNumberShow, VanillaEventChains
 from ..Files import APTokenTypes
 
 if TYPE_CHECKING:
@@ -670,148 +669,6 @@ def _starting_town_valid(world: "PokemonCrystalWorld", starting_town: StartingTo
                 not world.options.route_12_access and kanto_shopsanity) or full_kanto_trainersanity
 
     return True
-
-
-def get_fly_regions(world: "PokemonCrystalWorld") -> list[FlyRegion]:
-    fly_regions = list(data.fly_regions)
-
-    if world.options.johto_only == JohtoOnly.option_on:
-        fly_regions = [region for region in fly_regions if region.name != "Silver Cave"]
-
-    if world.options.johto_only:
-        fly_regions = [region for region in fly_regions if region.johto]
-
-    if world.options.randomize_fly_destinations:
-        # shuffled destinations fill flypoint slots by id, so the pool has to stay contiguous
-        fly_regions = [region for region in fly_regions if region.id <= len(fly_regions)]
-
-    return fly_regions
-
-
-def get_free_fly_locations(world: "PokemonCrystalWorld"):
-    location_pool = data.fly_regions[:]
-
-    if not world.options.randomize_starting_town:
-        location_pool = \
-            [region for region in location_pool if not region.exclude_vanilla_start]
-        if world.options.route_32_condition.value != Route32Condition.option_any_badge:
-            # Azalea, Goldenrod
-            location_pool = [region for region in location_pool if region.name not in ("Azalea Town", "Goldenrod City")]
-        if not world.options.remove_ilex_cut_tree and world.options.route_32_condition.value != Route32Condition.option_any_badge:
-            # Goldenrod
-            location_pool = [region for region in location_pool if region.name != "Goldenrod City"]
-    available_regions = set(get_fly_regions(world))
-    location_pool = [region for region in location_pool if region in available_regions]
-
-    if world.options.randomize_starting_town:
-        world.options.free_fly_blocklist.value.add(world.starting_town.name)
-
-    blocklist = set(world.options.free_fly_blocklist.value)
-    if "_Johto" in blocklist:
-        blocklist.remove("_Johto")
-        blocklist.update(town.name for town in data.fly_regions if town.johto)
-    if "_Kanto" in blocklist:
-        blocklist.remove("_Kanto")
-        blocklist.update(town.name for town in data.fly_regions if not town.johto)
-
-    # only do any of this if there even is a fly location blocklist
-    if blocklist:
-
-        # figure out how many fly locations are needed
-        locations_required = 1
-        if world.options.free_fly_location.value == FreeFlyLocation.option_free_fly_and_map_card:
-            locations_required = 2
-
-        # calculate what the list of locations would be after the blocklist
-        location_pool_after_blocklist = [item for item in location_pool if
-                                         item.name not in blocklist]
-
-        # if the list after the blocked locations are removed is long enough to satisfy all the requested fly locations, set the location pool to it
-        if len(location_pool_after_blocklist) >= locations_required:
-            location_pool = location_pool_after_blocklist
-        else:
-            logging.warning("Pokemon Crystal: All valid free fly locations blocked for player %s (%s). "
-                            "Using global list instead.", world.player, world.player_name)
-
-    world.random.shuffle(location_pool)
-    if world.options.free_fly_location.value in (FreeFlyLocation.option_free_fly,
-                                                 FreeFlyLocation.option_free_fly_and_map_card):
-        world.free_fly_location = location_pool.pop()
-    if world.options.free_fly_location.value in (FreeFlyLocation.option_free_fly_and_map_card,
-                                                 FreeFlyLocation.option_map_card):
-        world.map_card_fly_location = location_pool.pop()
-
-
-@functools.cache
-def _arrival_index() -> dict[tuple[str, int], list]:
-    index = defaultdict(list)
-    for conn in data.entrance_connections.values():
-        index[(conn.arrival_map, conn.arrival_warp_index)].append(conn)
-    return index
-
-
-def flypoint_arrival_connections(flypoint: FlypointWarp) -> list:
-    """Connections whose arrival is this flypoint's warp tile."""
-    return _arrival_index().get((flypoint.map_name, flypoint.warp_index), [])
-
-
-def _get_flyable_warps() -> dict[Landmark, list[FlypointWarp]]:
-    flypoints = {
-        l: [flypoint for flypoint in flypoints if flypoint_arrival_connections(flypoint)]
-        for l, flypoints in data.flypoints.items()
-    }
-    flypoints[Landmark.NationalPark] = [
-        flypoint for flypoint in flypoints[Landmark.NationalPark]
-        if flypoint.map_name != "NationalParkBugContest"
-    ]
-    return flypoints
-
-
-def randomize_fly_destinations(world: "PokemonCrystalWorld"):
-    if world.is_universal_tracker or not world.options.randomize_fly_destinations: return
-
-    def flyable_filter(flypoint):
-        if not world.options.route_23_restored and flypoint.map_name == "Route23Restored":
-            return False
-        # A flypoint targets a specific warp tile on an outdoor map; that tile
-        # may sit in a sub-region gated by another option (e.g. the Flooded
-        # Mine entrance tile lives in REGION_CHERRYGROVE_CITY:FLOODED_MINE_
-        # ENTRANCE, which only exists when flooded_mine is on). Drop those.
-        for conn in flypoint_arrival_connections(flypoint):
-            if not should_include_region(data.regions[conn.entrance_region], world):
-                return False
-        return True
-
-    if world.options.johto_only.value == JohtoOnly.option_off:
-        eligible_landmarks = Landmark.all()
-    else:
-        eligible_landmarks = Landmark.johto_only()
-
-    num_flypoints = len(get_fly_regions(world))
-
-    if world.options.johto_only.value == JohtoOnly.option_on \
-            or world.options.randomize_fly_unlocks.value == RandomizeFlyUnlocks.option_exclude_silver_cave:
-        eligible_landmarks.remove(Landmark.Route28)
-        eligible_landmarks.remove(Landmark.SilverCave)
-        # option_on already drops Silver Cave from the pool
-        if world.options.johto_only.value != JohtoOnly.option_on:
-            num_flypoints -= 1
-
-    flyable_flypoints = {
-        l: [flypoint for flypoint in flypoints if flyable_filter(flypoint)]
-        for l, flypoints in _get_flyable_warps().items()
-    }
-    eligible_landmarks = [l for l in eligible_landmarks if len(flyable_flypoints.get(l, [])) > 0]
-    selected_landmarks = world.random.sample(eligible_landmarks, num_flypoints)
-    fly_destinations = [world.random.choice(flyable_flypoints[l]) for l in selected_landmarks]
-
-    if world.options.randomize_fly_unlocks.value == RandomizeFlyUnlocks.option_exclude_silver_cave \
-            and world.options.johto_only.value != JohtoOnly.option_on:
-        silver_index = next(fly_region.id for fly_region in data.fly_regions if fly_region.name == "Silver Cave")
-        silver_flypoint = data.flypoints[Landmark.SilverCave][0]
-        fly_destinations.insert(silver_index, silver_flypoint)
-
-    world.fly_destinations = fly_destinations
 
 
 def get_mart_slot_location_name(mart: str, index: int):

--- a/worlds/pokemon_crystal_prerelease/utils.py
+++ b/worlds/pokemon_crystal_prerelease/utils.py
@@ -492,6 +492,12 @@ def __adjust_options_fly_destination_rando(world: "PokemonCrystalWorld"):
                         "Disabling Always Unlock Fly Destinations for player %s.",
                         world.player_name)
 
+    if world.options.randomize_fly_destinations and any(world.options.free_fly_blocklist.value):
+        world.options.free_fly_blocklist.value.clear()
+        logging.warning("Pokemon Crystal: Free Fly Blocklist is incompatible with Fly Destination Randomization. "
+                        "Disabling Free Fly Blocklist for player %s.",
+                        world.player_name)
+
 
 def __adjust_options_start_time(world: "PokemonCrystalWorld"):
     if parse_time(world.options.start_time.value) is None:

--- a/worlds/pokemon_crystal_prerelease/world.py
+++ b/worlds/pokemon_crystal_prerelease/world.py
@@ -1015,9 +1015,13 @@ class PokemonCrystalWorld(EntranceRandoMixin, CachedRuleBuilderWorld):
 
         if self.options.randomize_fly_destinations:
             spoiler_handle.write(f"Fly Destinations:\n")
-            for i, flypoint in enumerate(self.fly_destinations, start=1):
-                spoiler_handle.write(f"Fly Destination {i}: {flypoint.map_name} "
-                                     f"({flypoint.x}, {flypoint.y})\n")
+            fly_destination_names = [next(friendly_entrance_name(name)
+                                          for name, conn in crystal_data.entrance_connections.items()
+                                          if conn.exit_warps[0].map_name == flypoint.map_name
+                                          and flypoint.warp_index in (w.warp_index for w in conn.exit_warps))
+                                     for flypoint in self.fly_destinations]
+            for i, destination in enumerate(fly_destination_names, start=1):
+                spoiler_handle.write(f"Fly Destination {i}: {destination}\n")
 
         if self.er_pairings:
             spoiler_handle.write(f"\nEntrances ({self.player_name}):\n")

--- a/worlds/pokemon_crystal_prerelease/world.py
+++ b/worlds/pokemon_crystal_prerelease/world.py
@@ -1004,11 +1004,17 @@ class PokemonCrystalWorld(EntranceRandoMixin, CachedRuleBuilderWorld):
 
         if self.options.free_fly_location.value in (FreeFlyLocation.option_free_fly,
                                                     FreeFlyLocation.option_free_fly_and_map_card):
-            spoiler_handle.write(f"Free Fly Location: {self.free_fly_location.name}\n")
+            if not self.options.randomize_fly_destinations:
+                spoiler_handle.write(f"Free Fly Location: {self.free_fly_location.name}\n")
+            else:
+                spoiler_handle.write(f"Free Fly Location: Fly Unlock {self.free_fly_location.id}\n")
 
         if self.options.free_fly_location.value in (FreeFlyLocation.option_free_fly_and_map_card,
                                                     FreeFlyLocation.option_map_card):
-            spoiler_handle.write(f"Map Card Fly Location: {self.map_card_fly_location.name}\n")
+            if not self.options.randomize_fly_destinations:
+                spoiler_handle.write(f"Map Card Fly Location: {self.map_card_fly_location.name}\n")
+            else:
+                spoiler_handle.write(f"Map Card Fly Location: Fly Unlock {self.map_card_fly_location.id}\n")
 
         if self.options.randomize_starting_town:
             spoiler_handle.write(f"Starting Town: {self.starting_town.name}\n")

--- a/worlds/pokemon_crystal_prerelease/world.py
+++ b/worlds/pokemon_crystal_prerelease/world.py
@@ -17,6 +17,7 @@ from .data import PokemonData, TrainerData, MiscData, TMHMData, data as crystal_
     EncounterMon, EvolutionType, TypeData, BugContestEncounter, FlypointWarp, friendly_entrance_name, \
     FRIENDLY_CONNECTION_NAME_OVERRIDES
 from .evolution import randomize_evolution, evolution_in_logic
+from .fly import get_free_fly_locations, randomize_fly_destinations
 from .item_data import POKEDEX_OFFSET
 from .items import PokemonCrystalItem, create_item_label_to_code_map, ITEM_GROUPS, \
     item_const_name_to_id, item_const_name_to_label, get_classification_override, get_random_filler_item, \
@@ -47,8 +48,8 @@ from .rules import set_rules, PokemonCrystalLogic, verify_hm_accessibility
 from .sign_data import FRIENDLY_SIGN_NAMES
 from .trainers import set_rival_starter_pokemon, randomize_trainers, scale_red_levels
 from .universal_tracker import load_ut_slot_data
-from .utils import get_free_fly_locations, randomize_starting_town, randomize_fly_destinations, adjust_options, \
-    randomize_rival, pretty_region_name, validate_start_inventory
+from .utils import randomize_starting_town, adjust_options, randomize_rival, pretty_region_name, \
+    validate_start_inventory
 from .wild import randomize_wild_pokemon, randomize_static_pokemon, filter_time_of_day
 
 


### PR DESCRIPTION
## What does this add?
Lots of polishing to all things Fly Destination Rando

- When Fly Destination Rando is on but Fly Unlock Shuffle is off, write the items as if they were local flag items instead of vanilla handling, that way users can still get the "<Player> can FLY to <Landmark>!" popup
- Make the spoiler use friendly connection names instead of the raw map name and coordinates
- Fly Destination Plando and Blocklist options, along with their documentation
  - It is possible to plando specific entrance warps or a whole map, which then picks a warp at random
  - Pinning Silver Cave to vanilla on Exclude Silver Cave Fly Unlock Shuffle is done directly via plando
  - Refactored the TM Plando option to make the WeightedOptionDict class (valid_values and value weights) and have Fly Destination Plando inherit it
- `utils.py` was getting crowded with fly-related code, so I put it all in a dedicated file
- Create new items for "generic" fly unlocks when Fly destinations are randomized, to not cause confusion with regular fly items

## Why do you want it to be added?
I wasn't done

## Was this tested yet?
Tried all edge cases and causes for a plando entry to be ignored that I could think of with Destination Plando. I also generated several seeds with Route 30 (map) plandoed and Berry House blocklisted to check that Mr Pokemon's House was guaranteed to be picked.
Did not extensively test the item ID changes, but I did try playing a solo seed and checking that item names were correct for the settings I used. I also tried `!getitem`ing Fly Unlock 13 and it was processed correctly in-game.